### PR TITLE
Update scrypt.go

### DIFF
--- a/scrypt/scrypt.go
+++ b/scrypt/scrypt.go
@@ -218,7 +218,7 @@ func smix(b []byte, r, N int, v, xy []uint32) {
 // For example, you can get a derived key for e.g. AES-256 (which needs a
 // 32-byte key) by doing:
 //
-//      dk := scrypt.Key([]byte("some password"), salt, 16384, 8, 1, 32)
+//      dk, err := scrypt.Key([]byte("some password"), salt, 16384, 8, 1, 32)
 //
 // The recommended parameters for interactive logins as of 2009 are N=16384,
 // r=8, p=1. They should be increased as memory latency and CPU parallelism


### PR DESCRIPTION
scrypt.Key returns an err value. Code given as an example will not compile.