### PR TITLE
Probable typing error in line 68?

### DIFF
--- a/pkcs12/pkcs12.go
+++ b/pkcs12/pkcs12.go
@@ -65,7 +65,7 @@ type safeBag struct {
 
 type pkcs12Attribute struct {
 	Id    asn1.ObjectIdentifier
-	Value asn1.RawValue `ans1:"set"`
+	Value asn1.RawValue `asn1:"set"`
 }
 
 type encryptedPrivateKeyInfo struct {


### PR DESCRIPTION
Should this line:
	Value asn1.RawValue `ans1:"set"`
be:
	Value asn1.RawValue `asn1:"set"`
instead?