### PR TITLE
Set Channel method

### DIFF
--- a/ssh/session.go
+++ b/ssh/session.go
@@ -145,6 +145,12 @@ type Session struct {
 	exitStatus chan error
 }
 
+// Set channel
+func (s *Session) SetChannel(ch Channel) {
+	s.ch = ch
+}
+
+
 // SendRequest sends an out-of-band channel request on the SSH channel
 // underlying the session.
 func (s *Session) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {

--- a/ssh/session.go
+++ b/ssh/session.go
@@ -150,7 +150,6 @@ func (s *Session) SetChannel(ch Channel) {
 	s.ch = ch
 }
 
-
 // SendRequest sends an out-of-band channel request on the SSH channel
 // underlying the session.
 func (s *Session) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {


### PR DESCRIPTION
I think once we have OpenChannel we need to have this method to be able to create a new session 

for example:
func NewSession(c *ssh.Client) (*ssh.Session, error) {
	ch, _, err := c.OpenChannel("session", nil)
	if err != nil {
		return nil, err
	}
	s := &ssh.Session{}
	s.SetChannel(ch)
	return s, nil
}