### PR TITLE
package direction is wrong.

### DIFF
--- a/bcrypt/bcrypt.go
+++ b/bcrypt/bcrypt.go
@@ -12,7 +12,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/blowfish"
+	"github.com/golang/crypto/blowfish"
 	"io"
 	"strconv"
 )


### PR DESCRIPTION
When I run my code, an error message always prompt 
"unable to deduce repository and source type for: "golang.org/x/crypto/blowfish"
It seems that it uses 'golang.org' not 'github.com'