### PR TITLE
Add maxTries to server.go password authentication

### DIFF
--- a/ssh/server.go
+++ b/ssh/server.go
@@ -266,6 +266,9 @@ func (s *connection) serverAuthenticate(config *ServerConfig) (*Permissions, err
 	sessionID := s.transport.getSessionID()
 	var cache pubKeyCache
 	var perms *Permissions
+	// addition to break after maxTries
+	var count = 0
+	const maxTries = 3
 
 userAuthLoop:
 	for {
@@ -305,6 +308,12 @@ userAuthLoop:
 			}
 
 			perms, authErr = config.PasswordCallback(s, password)
+			// addition to break after maxTries
+			if count >= maxTries {
+				authErr = errors.New("ssh: maxTries reached")
+				break
+			}
+
 		case "keyboard-interactive":
 			if config.KeyboardInteractiveCallback == nil {
 				authErr = errors.New("ssh: keyboard-interactive auth not configubred")


### PR DESCRIPTION
I noticed a maxTries function was missing from the password authentication module.
Although the RFC suggests 20 attempts, most (but not all) clients back off after 3 tries.
With the current configuration (maxTries=3) after 4 tries the client will be disconnected. 