### PR TITLE
Remove misleading comments from G1 and G2 add

### DIFF
--- a/bn256/bn256.go
+++ b/bn256/bn256.go
@@ -73,7 +73,6 @@ func (e *G1) ScalarMult(a *G1, k *big.Int) *G1 {
 }
 
 // Add sets e to a+b and then returns e.
-// BUG(agl): this function is not complete: a==b fails.
 func (e *G1) Add(a, b *G1) *G1 {
 	if e.p == nil {
 		e.p = newCurvePoint(nil)
@@ -190,7 +189,6 @@ func (e *G2) ScalarMult(a *G2, k *big.Int) *G2 {
 }
 
 // Add sets e to a+b and then returns e.
-// BUG(agl): this function is not complete: a==b fails.
 func (e *G2) Add(a, b *G2) *G2 {
 	if e.p == nil {
 		e.p = newTwistPoint(nil)


### PR DESCRIPTION
Point doubling case for x == y in G1 and G2 is properly implemented inside curve.go and twist.go