### PR TITLE
acme/autocert: return error from cachePut

### DIFF
--- a/acme/autocert/renewal.go
+++ b/acme/autocert/renewal.go
@@ -102,7 +102,9 @@ func (dr *domainRenewal) do(ctx context.Context) (time.Duration, error) {
 	if err != nil {
 		return 0, err
 	}
-	dr.m.cachePut(ctx, dr.domain, tlscert)
+	if err := dr.m.cachePut(ctx, dr.domain, tlscert); err != nil {
+		return 0, err
+	}
 	dr.m.stateMu.Lock()
 	defer dr.m.stateMu.Unlock()
 	// m.state is guaranteed to be non-nil at this point


### PR DESCRIPTION
Fixes https://github.com/golang/go/issues/23569