### PR TITLE
acme: add authorization expiration timestamp

### DIFF
--- a/acme/types.go
+++ b/acme/types.go
@@ -194,6 +194,9 @@ type Authorization struct {
 	// Status identifies the status of an authorization.
 	Status string
 
+	// Optional expiration of an authorization.
+	Expires time.Time
+
 	// Identifier is what the account is authorized to represent.
 	Identifier AuthzID
 


### PR DESCRIPTION
Adds the expiration timestamp to acme authorization objects. This
lets ACME clients deterine the lifetime of a valid authorization
object.

See: https://tools.ietf.org/html/draft-ietf-acme-acme-10#section-7.1.4