### PR TITLE
pkcs12: add a DecodeAll method

### DIFF
--- a/pkcs12/pkcs12_test.go
+++ b/pkcs12/pkcs12_test.go
@@ -31,6 +31,34 @@ func TestPfx(t *testing.T) {
 	}
 }
 
+func TestPfxDecodeAll(t *testing.T) {
+	for commonName, base64P12 := range testdata {
+		p12, _ := base64.StdEncoding.DecodeString(base64P12)
+
+		privs, certs, err := DecodeAll(p12, "")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(privs) != 1 {
+			t.Errorf("expected 1 private key, but got %d", len(privs))
+		}
+
+		if len(certs) != 1 {
+			t.Errorf("expected 1 certificate, but got %d", len(certs))
+		}
+
+		if err := privs[0].(*rsa.PrivateKey).Validate(); err != nil {
+			t.Errorf("error while validating private key: %v", err)
+		}
+
+		if certs[0].Subject.CommonName != commonName {
+			t.Errorf("expected common name to be %q, but found %q", commonName, certs[0].Subject.CommonName)
+		}
+	}
+}
+
 func TestPEM(t *testing.T) {
 	for commonName, base64P12 := range testdata {
 		p12, _ := base64.StdEncoding.DecodeString(base64P12)


### PR DESCRIPTION
Addition of a DecodeAll function as it was mentioned in #14015.

This solves a need many people seem to have, where there is no effective
way loading PKCS12 files that contain more than one certificate and one
private key.

The utility functions used by Decode are all internal, which makes
implementing this on the user-side tedious, hence the suggestion of
providing a more liberal version of the function: DecodeAll.

Fixes golang/go#14015