### PR TITLE
xts: reduce tweak allocations

### DIFF
--- a/xts/xts.go
+++ b/xts/xts.go
@@ -30,8 +30,8 @@ import (
 	"golang.org/x/crypto/internal/subtle"
 )
 
-// Cipher contains an expanded key structure. It doesn't contain mutable state
-// and therefore can be used concurrently.
+// Cipher contains an expanded key structure. It is safe for concurrent use if
+// the underlying block cipher is safe for concurrent use.
 type Cipher struct {
 	k1, k2 cipher.Block
 }

--- a/xts/xts.go
+++ b/xts/xts.go
@@ -25,6 +25,7 @@ import (
 	"crypto/cipher"
 	"encoding/binary"
 	"errors"
+	"sync"
 
 	"golang.org/x/crypto/internal/subtle"
 )
@@ -38,6 +39,12 @@ type Cipher struct {
 // blockSize is the block size that the underlying cipher must have. XTS is
 // only defined for 16-byte ciphers.
 const blockSize = 16
+
+var tweakPool = sync.Pool{
+	New: func() interface{} {
+		return new([blockSize]byte)
+	},
+}
 
 // NewCipher creates a Cipher given a function for creating the underlying
 // block cipher (which must have a block size of 16 bytes). The key must be
@@ -70,7 +77,10 @@ func (c *Cipher) Encrypt(ciphertext, plaintext []byte, sectorNum uint64) {
 		panic("xts: invalid buffer overlap")
 	}
 
-	var tweak [blockSize]byte
+	tweak := tweakPool.Get().(*[blockSize]byte)
+	for i := range tweak {
+		tweak[i] = 0
+	}
 	binary.LittleEndian.PutUint64(tweak[:8], sectorNum)
 
 	c.k2.Encrypt(tweak[:], tweak[:])
@@ -86,8 +96,10 @@ func (c *Cipher) Encrypt(ciphertext, plaintext []byte, sectorNum uint64) {
 		plaintext = plaintext[blockSize:]
 		ciphertext = ciphertext[blockSize:]
 
-		mul2(&tweak)
+		mul2(tweak)
 	}
+
+	tweakPool.Put(tweak)
 }
 
 // Decrypt decrypts a sector of ciphertext and puts the result into plaintext.
@@ -104,7 +116,10 @@ func (c *Cipher) Decrypt(plaintext, ciphertext []byte, sectorNum uint64) {
 		panic("xts: invalid buffer overlap")
 	}
 
-	var tweak [blockSize]byte
+	tweak := tweakPool.Get().(*[blockSize]byte)
+	for i := range tweak {
+		tweak[i] = 0
+	}
 	binary.LittleEndian.PutUint64(tweak[:8], sectorNum)
 
 	c.k2.Encrypt(tweak[:], tweak[:])
@@ -120,8 +135,10 @@ func (c *Cipher) Decrypt(plaintext, ciphertext []byte, sectorNum uint64) {
 		plaintext = plaintext[blockSize:]
 		ciphertext = ciphertext[blockSize:]
 
-		mul2(&tweak)
+		mul2(tweak)
 	}
+
+	tweakPool.Put(tweak)
 }
 
 // mul2 multiplies tweak by 2 in GF(2¹²⁸) with an irreducible polynomial of

--- a/xts/xts_test.go
+++ b/xts/xts_test.go
@@ -103,3 +103,19 @@ func TestShorterCiphertext(t *testing.T) {
 		t.Errorf("En/Decryption is not inverse")
 	}
 }
+
+func BenchmarkXTS(b *testing.B) {
+	b.ReportAllocs()
+	c, err := NewCipher(aes.NewCipher, make([]byte, 32))
+	if err != nil {
+		b.Fatalf("NewCipher failed: %s", err)
+	}
+	plaintext := make([]byte, 32)
+	encrypted := make([]byte, 48)
+	decrypted := make([]byte, 48)
+
+	for i := 0; i < b.N; i++ {
+		c.Encrypt(encrypted, plaintext, 0)
+		c.Decrypt(decrypted, encrypted[:len(plaintext)], 0)
+	}
+}


### PR DESCRIPTION
The call to k2.Encrypt causes tweak to escape to the heap, resulting
in a 16-byte allocation for each call to Encrypt/Decrypt. Moving
tweak into the Cipher struct would allow it to be reused, but this
is ruled out by the Cipher docstring, which states that it is safe
for concurrent use. Instead, manage tweak arrays with a sync.Pool.
Benchmarks indicate that this amortizes allocation cost without
impacting performance.

benchmark          old ns/op     new ns/op     delta
BenchmarkXTS-4     234           245           +4.70%

benchmark          old allocs    new allocs    delta
BenchmarkXTS-4     2             0             -100.00%

benchmark          old bytes     new bytes     delta
BenchmarkXTS-4     32            0             -100.00%