### PR TITLE
ssh: support SSH agent signature flags and custom extensions

### DIFF
--- a/ssh/agent/client.go
+++ b/ssh/agent/client.go
@@ -79,8 +79,8 @@ type ExtendedAgent interface {
 	// required to support any extensions, but this method allows agents to implement
 	// vendor-specific methods or add experimental features. See [PROTOCOL.agent] section 4.7.
 	// If agent extensions are unsupported entirely this method MUST return an
-	// ErrAgentExtensionUnsupported error. Similarly, if just the specific extensionType in
-	// the request is unsupported by the agent then ErrAgentExtensionUnsupported MUST be
+	// ErrExtensionUnsupported error. Similarly, if just the specific extensionType in
+	// the request is unsupported by the agent then ErrExtensionUnsupported MUST be
 	// returned.
 	//
 	// In the case of success, since [PROTOCOL.agent] section 4.7 specifies that the contents
@@ -215,13 +215,13 @@ type constrainExtensionAgentMsg struct {
 const agentExtension = 27
 const agentExtensionFailure = 28
 
-// ErrAgentExtensionUnsupported indicates that an extension defined in
+// ErrExtensionUnsupported indicates that an extension defined in
 // [PROTOCOL.agent] section 4.7 is unsupported by the agent. Specifically this
 // error indicates that the agent returned a standard SSH_AGENT_FAILURE message
 // as the result of a SSH_AGENTC_EXTENSION request. Note that the protocol
 // specification (and therefore this error) does not distinguish between a
 // specific extension being unsupported and extensions being unsupported entirely.
-var ErrAgentExtensionUnsupported = errors.New("agent: agent extension unsupported")
+var ErrExtensionUnsupported = errors.New("agent: extension unsupported")
 
 type extensionAgentMsg struct {
 	ExtensionType string `sshtype:"27"`
@@ -779,7 +779,7 @@ func (c *client) Extension(extensionType string, contents []byte) ([]byte, error
 	// [PROTOCOL.agent] section 4.7 indicates that an SSH_AGENT_FAILURE message
 	// represents an agent that does not support the extension
 	if buf[0] == agentFailure {
-		return nil, ErrAgentExtensionUnsupported
+		return nil, ErrExtensionUnsupported
 	}
 	if buf[0] == agentExtensionFailure {
 		return nil, errors.New("agent: generic extension failure")

--- a/ssh/agent/client.go
+++ b/ssh/agent/client.go
@@ -214,6 +214,7 @@ type constrainExtensionAgentMsg struct {
 // See [PROTOCOL.agent], section 4.7
 const agentExtension = 27
 const agentExtensionFailure = 28
+
 // ErrAgentExtensionUnsupported indicates that an extension defined in
 // [PROTOCOL.agent] section 4.7 is unsupported by the agent. Specifically this
 // error indicates that the agent returned a standard SSH_AGENT_FAILURE message

--- a/ssh/agent/client_test.go
+++ b/ssh/agent/client_test.go
@@ -177,9 +177,9 @@ func testAgentInterface(t *testing.T, agent ExtendedAgent, key interface{}, cert
 				t.Fatalf("Verify(%s): %v", pubKey.Type(), err)
 			}
 		}
-		sshFlagTest(0, "ssh-rsa")
-		sshFlagTest(SignatureFlagRsaSha256, "rsa-sha2-256")
-		sshFlagTest(SignatureFlagRsaSha512, "rsa-sha2-512")
+		sshFlagTest(0, ssh.SigAlgoRSA)
+		sshFlagTest(SignatureFlagRsaSha256, ssh.SigAlgoRSASHA2256)
+		sshFlagTest(SignatureFlagRsaSha512, ssh.SigAlgoRSASHA2512)
 	}
 
 	// If the key has a lifetime, is it removed when it should be?

--- a/ssh/agent/keyring.go
+++ b/ssh/agent/keyring.go
@@ -236,5 +236,5 @@ func (r *keyring) Signers() ([]ssh.Signer, error) {
 
 // The keyring does not support any extensions
 func (r *keyring) Extension(extensionType string, contents []byte) ([]byte, error) {
-	return []byte{agentExtensionFailure}, nil
+	return nil, ErrAgentExtensionUnsupported
 }

--- a/ssh/agent/keyring.go
+++ b/ssh/agent/keyring.go
@@ -237,5 +237,5 @@ func (r *keyring) Signers() ([]ssh.Signer, error) {
 
 // The keyring does not support any extensions
 func (r *keyring) Extension(extensionType string, contents []byte) ([]byte, error) {
-	return nil, ErrAgentExtensionUnsupported
+	return nil, ErrExtensionUnsupported
 }

--- a/ssh/agent/keyring.go
+++ b/ssh/agent/keyring.go
@@ -233,3 +233,8 @@ func (r *keyring) Signers() ([]ssh.Signer, error) {
 	}
 	return s, nil
 }
+
+// The keyring does not support any extensions
+func (r *keyring) Extension(extensionType string, contents []byte) ([]byte, error) {
+	return []byte{agentExtensionFailure}, nil
+}

--- a/ssh/agent/server.go
+++ b/ssh/agent/server.go
@@ -177,7 +177,7 @@ func (s *server) processRequest(data []byte) (interface{}, error) {
 			if err != nil {
 				// If agent extensions are unsupported, return a standard SSH_AGENT_FAILURE
 				// message as required by [PROTOCOL.agent] section 4.7.
-				if err == ErrAgentExtensionUnsupported {
+				if err == ErrExtensionUnsupported {
 					responseStub.Rest = []byte{agentFailure}
 				} else {
 					// As the result of any other error processing an extension request,

--- a/ssh/agent/server.go
+++ b/ssh/agent/server.go
@@ -128,7 +128,14 @@ func (s *server) processRequest(data []byte) (interface{}, error) {
 			Blob:   req.KeyBlob,
 		}
 
-		sig, err := s.agent.Sign(k, req.Data) //  TODO(hanwen): flags.
+		var sig *ssh.Signature
+		var err error
+		if extendedAgent, ok := s.agent.(ExtendedAgent); ok {
+			sig, err = extendedAgent.SignWithFlags(k, req.Data, SignatureFlags(req.Flags))
+		} else {
+			sig, err = s.agent.Sign(k, req.Data)
+		}
+
 		if err != nil {
 			return nil, err
 		}

--- a/ssh/agent/server.go
+++ b/ssh/agent/server.go
@@ -157,6 +157,32 @@ func (s *server) processRequest(data []byte) (interface{}, error) {
 
 	case agentAddIDConstrained, agentAddIdentity:
 		return nil, s.insertIdentity(data)
+
+	case agentExtension:
+		// Return a stub object where the whole contents of the response gets marshaled.
+		var responseStub struct {
+			Rest []byte `ssh:"rest"`
+		}
+
+		if extendedAgent, ok := s.agent.(ExtendedAgent); !ok {
+			// If this agent doesn't implement extensions, just return a failure message
+			responseStub.Rest = []byte{agentExtensionFailure}
+		} else {
+			var req extensionAgentMsg
+			if err := ssh.Unmarshal(data, &req); err != nil {
+				return nil, err
+			}
+			res, err := extendedAgent.Extension(req.ExtensionType, req.Contents)
+			if err != nil {
+				return nil, err
+			}
+			if len(res) == 0 {
+				return nil, nil
+			}
+			responseStub.Rest = res
+		}
+
+		return responseStub, nil
 	}
 
 	return nil, fmt.Errorf("unknown opcode %d", data[0])

--- a/ssh/certs.go
+++ b/ssh/certs.go
@@ -6,7 +6,6 @@ package ssh
 
 import (
 	"bytes"
-	"crypto"
 	"errors"
 	"fmt"
 	"io"
@@ -223,9 +222,9 @@ type openSSHCertSigner struct {
 	signer Signer
 }
 
-type parameterizedOpenSSHCertSigner struct {
+type algorithmOpenSSHCertSigner struct {
 	*openSSHCertSigner
-	parameterizedSigner ParameterizedSigner
+	algorgitmSigner AlgorithmSigner
 }
 
 // NewCertSigner returns a Signer that signs with the given Certificate, whose
@@ -236,9 +235,9 @@ func NewCertSigner(cert *Certificate, signer Signer) (Signer, error) {
 		return nil, errors.New("ssh: signer and cert have different public key")
 	}
 
-	if parameterizedSigner, ok := signer.(ParameterizedSigner); ok {
-		return &parameterizedOpenSSHCertSigner{
-			&openSSHCertSigner{cert, signer}, parameterizedSigner}, nil
+	if algorithmSigner, ok := signer.(AlgorithmSigner); ok {
+		return &algorithmOpenSSHCertSigner{
+			&openSSHCertSigner{cert, signer}, algorithmSigner}, nil
 	} else {
 		return &openSSHCertSigner{cert, signer}, nil
 	}
@@ -252,8 +251,8 @@ func (s *openSSHCertSigner) PublicKey() PublicKey {
 	return s.pub
 }
 
-func (s *parameterizedOpenSSHCertSigner) SignWithOpts(rand io.Reader, data []byte, opts crypto.SignerOpts) (*Signature, error) {
-	return s.parameterizedSigner.SignWithOpts(rand, data, opts)
+func (s *algorithmOpenSSHCertSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*Signature, error) {
+	return s.algorgitmSigner.SignWithAlgorithm(rand, data, algorithm)
 }
 
 const sourceAddressCriticalOption = "source-address"

--- a/ssh/certs.go
+++ b/ssh/certs.go
@@ -224,7 +224,7 @@ type openSSHCertSigner struct {
 
 type algorithmOpenSSHCertSigner struct {
 	*openSSHCertSigner
-	algorgitmSigner AlgorithmSigner
+	algorithmSigner AlgorithmSigner
 }
 
 // NewCertSigner returns a Signer that signs with the given Certificate, whose
@@ -252,7 +252,7 @@ func (s *openSSHCertSigner) PublicKey() PublicKey {
 }
 
 func (s *algorithmOpenSSHCertSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*Signature, error) {
-	return s.algorgitmSigner.SignWithAlgorithm(rand, data, algorithm)
+	return s.algorithmSigner.SignWithAlgorithm(rand, data, algorithm)
 }
 
 const sourceAddressCriticalOption = "source-address"

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -39,7 +39,9 @@ const (
 )
 
 // These constants represent non-default signature algorithms that are supported
-// as algorithm parameters to AlgorithmSigner.SignWithAlgorithm methods
+// as algorithm parameters to AlgorithmSigner.SignWithAlgorithm methods. See
+// [PROTOCOL.agent] section 4.5.1 and
+// https://tools.ietf.org/html/draft-ietf-curdle-rsa-sha2-10
 const (
 	SigAlgoRSA        = "ssh-rsa"
 	SigAlgoRSASHA2256 = "rsa-sha2-256"

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -38,6 +38,14 @@ const (
 	KeyAlgoED25519  = "ssh-ed25519"
 )
 
+// These constants represent non-default signature algorithms that are supported
+// as algorithm parameters to AlgorithmSigner.SignWithAlgorithm methods
+const (
+	SigAlgoRSA        = "ssh-rsa"
+	SigAlgoRSASHA2256 = "rsa-sha2-256"
+	SigAlgoRSASHA2512 = "rsa-sha2-512"
+)
+
 // parsePubKey parses a public key of the given algorithm.
 // Use ParsePublicKey for keys with prepended algorithm.
 func parsePubKey(in []byte, algo string) (pubKey PublicKey, rest []byte, err error) {
@@ -301,10 +309,17 @@ type Signer interface {
 	Sign(rand io.Reader, data []byte) (*Signature, error)
 }
 
-type ParameterizedSigner interface {
+// A AlgorithmSigner is a Signer that also supports specifying a specific
+// algorithm to use for signing.
+type AlgorithmSigner interface {
 	Signer
 
-	SignWithOpts(rand io.Reader, data []byte, opts crypto.SignerOpts) (*Signature, error)
+	// SignWithAlgorithm is like Signer.Sign, but allows specification of a
+	// non-default signing algorithm. See the SigAlgo* constants in this
+	// package for signature algorithms supported by this package. Callers may
+	// pass an empty string for the algorithm in which case the AlgorithmSigner
+	// will use its default algorithm.
+	SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*Signature, error)
 }
 
 type rsaPublicKey rsa.PublicKey
@@ -357,11 +372,11 @@ func (r *rsaPublicKey) Marshal() []byte {
 func (r *rsaPublicKey) Verify(data []byte, sig *Signature) error {
 	var hash crypto.Hash
 	switch sig.Format {
-	case "ssh-rsa":
+	case SigAlgoRSA:
 		hash = crypto.SHA1
-	case "rsa-sha2-256":
+	case SigAlgoRSASHA2256:
 		hash = crypto.SHA256
-	case "rsa-sha2-512":
+	case SigAlgoRSASHA2512:
 		hash = crypto.SHA512
 	default:
 		return fmt.Errorf("ssh: signature type %s for key type %s", sig.Format, r.Type())
@@ -473,6 +488,14 @@ func (k *dsaPrivateKey) PublicKey() PublicKey {
 }
 
 func (k *dsaPrivateKey) Sign(rand io.Reader, data []byte) (*Signature, error) {
+	return k.SignWithAlgorithm(rand, data, "")
+}
+
+func (k *dsaPrivateKey) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*Signature, error) {
+	if algorithm != "" && algorithm != k.PublicKey().Type() {
+		return nil, fmt.Errorf("ssh: unsupported signature algorithm %s", algorithm)
+	}
+
 	h := crypto.SHA1.New()
 	h.Write(data)
 	digest := h.Sum(nil)
@@ -705,17 +728,35 @@ func (s *wrappedSigner) PublicKey() PublicKey {
 }
 
 func (s *wrappedSigner) Sign(rand io.Reader, data []byte) (*Signature, error) {
-	return s.SignWithOpts(rand, data, nil)
+	return s.SignWithAlgorithm(rand, data, "")
 }
 
-func (s *wrappedSigner) SignWithOpts(rand io.Reader, data []byte, opts crypto.SignerOpts) (*Signature, error) {
+func (s *wrappedSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*Signature, error) {
 	var hashFunc crypto.Hash
 
-	if opts != nil {
-		hashFunc = opts.HashFunc()
+	if _, ok := s.pubKey.(*rsaPublicKey); ok {
+		// RSA keys support a few hash functions determined by the requested signature algorithm
+		switch algorithm {
+		case "", SigAlgoRSA:
+			algorithm = SigAlgoRSA
+			hashFunc = crypto.SHA1
+		case SigAlgoRSASHA2256:
+			hashFunc = crypto.SHA256
+		case SigAlgoRSASHA2512:
+			hashFunc = crypto.SHA512
+		default:
+			return nil, fmt.Errorf("ssh: unsupported signature algorithm %s", algorithm)
+		}
 	} else {
+		// The only supported algorithm for all other key types is the same as the type of the key
+		if algorithm == "" {
+			algorithm = s.pubKey.Type()
+		} else if algorithm != s.pubKey.Type() {
+			return nil, fmt.Errorf("ssh: unsupported signature algorithm %s", algorithm)
+		}
+
 		switch key := s.pubKey.(type) {
-		case *rsaPublicKey, *dsaPublicKey:
+		case *dsaPublicKey:
 			hashFunc = crypto.SHA1
 		case *ecdsaPublicKey:
 			hashFunc = ecHash(key.Curve)
@@ -766,17 +807,8 @@ func (s *wrappedSigner) SignWithOpts(rand io.Reader, data []byte, opts crypto.Si
 		}
 	}
 
-	format := s.pubKey.Type()
-	if format == "ssh-rsa" {
-		if hashFunc == crypto.SHA256 {
-			format = "rsa-sha2-256"
-		} else if hashFunc == crypto.SHA512 {
-			format = "rsa-sha2-512"
-		}
-	}
-
 	return &Signature{
-		Format: format,
+		Format: algorithm,
 		Blob:   signature,
 	}, nil
 }

--- a/ssh/keys_test.go
+++ b/ssh/keys_test.go
@@ -117,38 +117,35 @@ func TestKeySignWithAlgorithmVerify(t *testing.T) {
 			pub := priv.PublicKey()
 			data := []byte("sign me")
 
+			signWithAlgTestCase := func(algorithm string, expectedAlg string) {
+				sig, err := algorithmSigner.SignWithAlgorithm(rand.Reader, data, algorithm)
+				if err != nil {
+					t.Fatalf("Sign(%T): %v", priv, err)
+				}
+				if sig.Format != expectedAlg {
+					t.Errorf("signature format did not match requested signature algorithm: %s != %s", sig.Format, expectedAlg)
+				}
+
+				if err := pub.Verify(data, sig); err != nil {
+					t.Errorf("publicKey.Verify(%T): %v", priv, err)
+				}
+				sig.Blob[5]++
+				if err := pub.Verify(data, sig); err == nil {
+					t.Errorf("publicKey.Verify on broken sig did not fail")
+				}
+			}
+
 			// Using the empty string as the algorithm name should result in the same signature format as the algorithm-free Sign method.
 			defaultSig, err := priv.Sign(rand.Reader, data)
 			if err != nil {
 				t.Fatalf("Sign(%T): %v", priv, err)
 			}
-			sigWithoutAlg, err := algorithmSigner.SignWithAlgorithm(rand.Reader, data, "")
-			if err != nil {
-				t.Fatalf("SignWithAlgorithm(%T): %v", algorithmSigner, err)
-			}
-			if defaultSig.Format != sigWithoutAlg.Format {
-				t.Errorf("Signature format without algorithm doesn't match default algorithm signature format: %s != %s",
-					defaultSig.Format, sigWithoutAlg.Format)
-			}
+			signWithAlgTestCase("", defaultSig.Format)
 
 			// RSA keys are the only ones which currently support more than one signing algorithm
 			if pub.Type() == KeyAlgoRSA {
-				for _, algorithm := range []string{"", SigAlgoRSA, SigAlgoRSASHA2256, SigAlgoRSASHA2512} {
-					sig, err := algorithmSigner.SignWithAlgorithm(rand.Reader, data, algorithm)
-					if err != nil {
-						t.Fatalf("Sign(%T): %v", priv, err)
-					}
-					if (algorithm == "" && sig.Format != SigAlgoRSA) || (algorithm != "" && sig.Format != algorithm) {
-						t.Errorf("signature format did not match requested signature algorithm: %s != %s", sig.Format, algorithm)
-					}
-
-					if err := pub.Verify(data, sig); err != nil {
-						t.Errorf("publicKey.Verify(%T): %v", priv, err)
-					}
-					sig.Blob[5]++
-					if err := pub.Verify(data, sig); err == nil {
-						t.Errorf("publicKey.Verify on broken sig did not fail")
-					}
+				for _, algorithm := range []string{SigAlgoRSA, SigAlgoRSASHA2256, SigAlgoRSASHA2512} {
+					signWithAlgTestCase(algorithm, algorithm)
 				}
 			}
 		}


### PR DESCRIPTION
This commit implements two new features. To preserve backwards
compatibility the new methods are added to an `ExtendedAgent` interface
which extends `Agent`. The client code implements `ExtendedAgent`
(which extends Agent) so you can call these additional methods against
SSH agents such as the OpenSSH agent. The ServeAgent method still
accepts Agent but will attempt to upcast the agent to `ExtendedAgent`
as needed, so if you supply an ExtendedAgent implementation you can
implement these additional methods (which keyring does).

The first feature is supporting the standard flags that can be passed to
SSH Sign requests, requesting that RSA signatures use SHA-256 or
SHA-512. See section 4.5.1 of the SSH agent protocol draft:
https://tools.ietf.org/html/draft-miller-ssh-agent-02

The second feature is supporting calling custom extensions from clients
and implementing custom extensions from servers. See section 4.7 of the
SSH agent protocol draft:
https://tools.ietf.org/html/draft-miller-ssh-agent-02