### PR TITLE
openpgp: Define s2k magic numbers as consts

### DIFF
--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	// determines the strength of the passphrase stretching when
 	// the said passphrase is hashed to produce a key. S2KCount
 	// should be between 1024 and 65011712, inclusive. If Config
-	// is nil or S2KCount is 0, the value 65536 used. Not all
+	// is nil or S2KCount is 0, the value S2KCountDefault used. Not all
 	// values in the above range can be represented. S2KCount will
 	// be rounded up to the next representable value if it cannot
 	// be encoded exactly. When set, it is strongly encrouraged to

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -29,7 +29,7 @@ const (
 
 	S2KUsageConventionPlaintextChecksum = 255
 
-	S2KUsageConventionEncryptedSha1 = 254
+	S2KUsageConventionEncryptedSHA1 = 254
 )
 
 // PrivateKey represents a possibly encrypted private key. See RFC 4880,
@@ -107,7 +107,7 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 	case S2KUsageConventionUnencrypted:
 		pk.s2k = nil
 		pk.Encrypted = false
-	case S2KUsageConventionEncryptedSha1, S2KUsageConventionPlaintextChecksum:
+	case S2KUsageConventionEncryptedSHA1, S2KUsageConventionPlaintextChecksum:
 		_, err = readFull(r, buf[:])
 		if err != nil {
 			return
@@ -118,7 +118,7 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 		if err != nil {
 			return
 		}
-		if s2kType == S2KUsageConventionEncryptedSha1 {
+		if s2kType == S2KUsageConventionEncryptedSHA1 {
 			pk.sha1Checksum = true
 		}
 	default:

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -65,11 +65,14 @@ func (c *Config) hash() crypto.Hash {
 }
 
 func (c *Config) encodedCount() uint8 {
+	var i int
+
 	if c == nil || c.S2KCount == 0 {
-		return 96 // The common case. Correspoding to 65536
+		i = S2KCountDefault
+	} else {
+		i = c.S2KCount
 	}
 
-	i := c.S2KCount
 	switch {
 	// Behave like GPG. Should we make 65536 the lowest value used?
 	case i < S2KCountMin:

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -39,7 +39,7 @@ const (
 	S2KCountMax = 65011712
 )
 
-type stringToKeySpecifier = uint8
+type stringToKeySpecifier uint8
 
 const (
 	// The simple string-to-key directly hashes the password string to
@@ -217,7 +217,7 @@ func Parse(r io.Reader) (f func(out, in []byte), err error) {
 	}
 	h := hash.New()
 
-	switch buf[0] {
+	switch stringToKeySpecifier(buf[0]) {
 	case simpleS2K:
 		f := func(out, in []byte) {
 			Simple(out, h, in)
@@ -253,7 +253,7 @@ func Parse(r io.Reader) (f func(out, in []byte), err error) {
 // nil. In that case, sensible defaults will be used.
 func Serialize(w io.Writer, key []byte, rand io.Reader, passphrase []byte, c *Config) error {
 	var buf [11]byte
-	buf[0] = iteratedAndSaltedS2K
+	buf[0] = byte(iteratedAndSaltedS2K)
 	buf[1], _ = HashToHashId(c.hash())
 	salt := buf[2:10]
 	if _, err := io.ReadFull(rand, salt); err != nil {

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -16,22 +16,26 @@ import (
 )
 
 const (
-	// When symmetrically encrypting with a passphrase, S2KCountMin is the
-	// minimum allowable parameter for the iterated and salted string to
-	// key (S2K) key derivation function.
+	// S2KCountMin is the minimum allowable parameter for the iterated and salted
+	// string to key (S2K) key derivation function for symmetrically encrypting
+	// with a passphrase.
 	// It provides the least protection against dictionary attacks. A
 	// higher value should be chosen instead.
+	// See https://tools.ietf.org/html/rfc4880#section-3.7.1.3
 	S2KCountMin = 1024
 
-	// When symmetrically encrypting with a passphrase, S2KCountDefault is
-	// the default parameter used for the iterated and salted string to key
-	// (S2K) key derivation function.
+	// S2KCountDefault is the default parameter used for the iterated and salted
+	// string to key (S2K) key derivation function for symmetrically encrypting
+	// with a passphrase.
+	// See https://tools.ietf.org/html/rfc4880#section-3.7.1.3
 	S2KCountDefault = 65536
 
-	// When symmetrically encrypting with a passphrase, S2KCountMax is the
-	// maximum allowable parameter for the iterated and salted string to
-	// key (S2K) key derivation function. It provides the highest security
-	// by requiring the most amount of work to perform a dictionary attack.
+	// S2KCountMax is the maximum allowable parameter for the iterated and salted
+	// string to key (S2K) key derivation function for symmetrically encrypting
+	// with a passphrase.
+	// It provides the highest security by requiring the most amount of work to
+	// perform a dictionary attack.
+	// See https://tools.ietf.org/html/rfc4880#section-3.7.1.3
 	S2KCountMax = 65011712
 )
 

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -16,9 +16,23 @@ import (
 )
 
 const (
-	S2KCountMin     = 1024
+	// When symmetrically encrypting with a passphrase, S2KCountMin is the
+	// minimum allowable parameter for the iterated and salted string to
+	// key (S2K) key derivation function.
+	// It provides the least protection against dictionary attacks. A
+	// higher value should be chosen instead.
+	S2KCountMin = 1024
+
+	// When symmetrically encrypting with a passphrase, S2KCountDefault is
+	// the default parameter used for the iterated and salted string to key
+	// (S2K) key derivation function.
 	S2KCountDefault = 65536
-	S2KCountMax     = 65011712
+
+	// When symmetrically encrypting with a passphrase, S2KCountMax is the
+	// maximum allowable parameter for the iterated and salted string to
+	// key (S2K) key derivation function. It provides the highest security
+	// by requiring the most amount of work to perform a dictionary attack.
+	S2KCountMax = 65011712
 )
 
 type stringToKeySpecifier = uint8

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -18,6 +18,12 @@ import (
 type stringToKeySpecifier = uint8
 
 const (
+	S2KCountMin     = 1024
+	S2KCountDefault = 65536
+	S2KCountMax     = 65011712
+)
+
+const (
 	// https://tools.ietf.org/html/rfc4880#section-3.7.1.1
 	SimpleS2K stringToKeySpecifier = 0
 
@@ -66,10 +72,10 @@ func (c *Config) encodedCount() uint8 {
 	i := c.S2KCount
 	switch {
 	// Behave like GPG. Should we make 65536 the lowest value used?
-	case i < 1024:
-		i = 1024
-	case i > 65011712:
-		i = 65011712
+	case i < S2KCountMin:
+		i = S2KCountMin
+	case i > S2KCountMax:
+		i = S2KCountMax
 	}
 
 	return encodeCount(i)
@@ -81,7 +87,7 @@ func (c *Config) encodedCount() uint8 {
 // if i is not in the above range (encodedCount above takes care to
 // pass i in the correct range). See RFC 4880 Section 3.7.7.1.
 func encodeCount(i int) uint8 {
-	if i < 1024 || i > 65011712 {
+	if i < S2KCountMin || i > S2KCountMax {
 		panic("count arg i outside the required range")
 	}
 


### PR DESCRIPTION
This PR factors out some magic numbers from the openpgp string-to-key code.

Please see the long descriptions in the individual commits.

These commits were some groundwork I laid for implementing encrypted private keys (serializing with a password). I'm submitting this as an initial (hopefully uncontroversial) pull request to get the feel for how you folks like to receive contributions.

Thanks for building crypto/openpgp ... it's been good to hack on, and I've got more contributions lined up for the future!