### PR TITLE
openpgp/packet/signature: output reason for revocation

### DIFF
--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -727,5 +727,21 @@ func (sig *Signature) buildSubpackets() (subpackets []outputSubpacket) {
 		subpackets = append(subpackets, outputSubpacket{true, prefCompressionSubpacket, false, sig.PreferredCompression})
 	}
 
+	if sig.SigType == SigTypeKeyRevocation {
+		reasonForRevData := bytes.NewBuffer(nil)
+		reasonForRevData.Write([]byte{*sig.RevocationReason})
+		reasonForRevData.Write([]byte(sig.RevocationReasonText))
+
+		subpackets = append(
+			subpackets,
+			outputSubpacket{
+				hashed:        true,
+				subpacketType: reasonForRevocationSubpacket,
+				isCritical:    false,
+				contents:      reasonForRevData.Bytes(),
+			},
+		)
+	}
+
 	return
 }


### PR DESCRIPTION
When building subpackets for a Signature, ensure a "reason for
revocation" subpacket is added if the Signature is a
SigTypeKeyRevocation.

Previously, the Signature fields `RevocationReason` and
`RevocationReasonText` were used only when *parsing* a revocation. This
change means they're also output in a subpacket if a revocation
signature is generated.

See https://tools.ietf.org/html/rfc4880#section-5.2.3.23