### PR TITLE
openpgp: use latest subkey binding signature

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -457,7 +457,8 @@ func addSubkey(e *Entity, packets *packet.Reader, pub *packet.PublicKey, priv *p
 		case packet.SigTypeSubkeyRevocation:
 			subKey.Sig = sig
 		case packet.SigTypeSubkeyBinding:
-			if subKey.Sig == nil {
+
+			if shouldReplaceSubkeySig(subKey.Sig, sig) {
 				subKey.Sig = sig
 			}
 		}
@@ -470,6 +471,22 @@ func addSubkey(e *Entity, packets *packet.Reader, pub *packet.PublicKey, priv *p
 	e.Subkeys = append(e.Subkeys, subKey)
 
 	return nil
+}
+
+func shouldReplaceSubkeySig(existingSig, potentialNewSig *packet.Signature) bool {
+	if potentialNewSig == nil {
+		return false
+	}
+
+	if existingSig == nil {
+		return true
+	}
+
+	if existingSig.SigType == packet.SigTypeSubkeyRevocation {
+		return false // never override a revocation signature
+	}
+
+	return potentialNewSig.CreationTime.After(existingSig.CreationTime)
 }
 
 const defaultRSAKeyBits = 2048


### PR DESCRIPTION
Rather than using the first subkey binding signature encountered, use
the one with the most recent creation data, as per the recommendation from
RFC 4880:

> An implementation that encounters multiple self-signatures on the
> same object may resolve the ambiguity in any way it sees fit, but it
> is RECOMMENDED that priority be given to the most recent self-
> signature.

This allows subkeys to approach expiry then be re-signed with a new expiry.

This extends the recent commit 0e37d00 by @aviau and @FiloSottile.

Fixes golang/go#26468