### PR TITLE
ssh: fix typo in error message

### DIFF
--- a/ssh/server.go
+++ b/ssh/server.go
@@ -393,7 +393,7 @@ userAuthLoop:
 			perms, authErr = config.PasswordCallback(s, password)
 		case "keyboard-interactive":
 			if config.KeyboardInteractiveCallback == nil {
-				authErr = errors.New("ssh: keyboard-interactive auth not configubred")
+				authErr = errors.New("ssh: keyboard-interactive auth not configured")
 				break
 			}
 


### PR DESCRIPTION
Fix typo in error message when keyboard-interactive auth not supported by server and client requests it