### PR TITLE
ssh/agent: Fix error returned from agent responses that are too big.

### DIFF
--- a/ssh/agent/client.go
+++ b/ssh/agent/client.go
@@ -284,7 +284,7 @@ func (c *client) call(req []byte) (reply interface{}, err error) {
 	}
 	respSize := binary.BigEndian.Uint32(respSizeBuf[:])
 	if respSize > maxAgentResponseBytes {
-		return nil, clientErr(err)
+		return nil, clientErr(errors.New("response too large"))
 	}
 
 	buf := make([]byte, respSize)

--- a/ssh/agent/client_test.go
+++ b/ssh/agent/client_test.go
@@ -218,6 +218,30 @@ func netPipe() (net.Conn, net.Conn, error) {
 	return c1, c2, nil
 }
 
+func TestServerResponseTooLarge(t *testing.T) {
+	a, b, err := netPipe()
+	if err != nil {
+		t.Fatalf("netPipe: %v", err)
+	}
+
+	defer a.Close()
+	defer b.Close()
+
+	var response identitiesAnswerAgentMsg
+	response.NumKeys = 1
+	response.Keys = make([]byte, maxAgentResponseBytes+1)
+
+	agent := NewClient(a)
+	go b.Write(ssh.Marshal(response))
+	_, err = agent.List()
+	if err == nil {
+		t.Fatal("Did not get error result")
+	}
+	if err.Error() != "agent: client error: response too large" {
+		t.Fatal("Did not get expected error result")
+	}
+}
+
 func TestAuth(t *testing.T) {
 	agent, _, cleanup := startOpenSSHAgent(t)
 	defer cleanup()


### PR DESCRIPTION
Make sure a meaningful error is returned when the SSH agent client receives
a response that is too big.