### PR TITLE
acme/autocert: include rejected hostname in TLS handshake error when host not configured

### DIFF
--- a/acme/autocert/autocert.go
+++ b/acme/autocert/autocert.go
@@ -69,7 +69,8 @@ func HostWhitelist(hosts ...string) HostPolicy {
 	}
 	return func(_ context.Context, host string) error {
 		if !whitelist[host] {
-			return errors.New("acme/autocert: host not configured")
+//			return errors.New("acme/autocert: host not configured")
+			return fmt.Errorf("acme/autocert: host not configured: %q", host)
 		}
 		return nil
 	}

--- a/acme/autocert/autocert.go
+++ b/acme/autocert/autocert.go
@@ -69,8 +69,7 @@ func HostWhitelist(hosts ...string) HostPolicy {
 	}
 	return func(_ context.Context, host string) error {
 		if !whitelist[host] {
-//			return errors.New("acme/autocert: host not configured")
-			return fmt.Errorf("acme/autocert: host not configured: %q", host)
+			return fmt.Errorf("acme/autocert: host %q not configured in HostWhitelist", host)
 		}
 		return nil
 	}


### PR DESCRIPTION
More informative error message enables HTTPS server configuration mistakes to be corrected quickly, since log files will now include the rejected hostname.  If the hostname should be accepted, it can be added to the HostWhitelist Policy.

Fixes golang/go#28345

