### PR TITLE
bn256: fix gfp12 MulScalar

### DIFF
--- a/bn256/gfp12.go
+++ b/bn256/gfp12.go
@@ -125,8 +125,8 @@ func (e *gfP12) Mul(a, b *gfP12, pool *bnPool) *gfP12 {
 }
 
 func (e *gfP12) MulScalar(a *gfP12, b *gfP6, pool *bnPool) *gfP12 {
-	e.x.Mul(e.x, b, pool)
-	e.y.Mul(e.y, b, pool)
+	e.x.Mul(a.x, b, pool)
+	e.y.Mul(a.y, b, pool)
 	return e
 }
 


### PR DESCRIPTION
Previously MulScalar was ignoring the first parameter, which was inconsistent with gfp6 and gfp2.