### PR TITLE
bn256: fix String methods when g.p == nil

### DIFF
--- a/bn256/bn256.go
+++ b/bn256/bn256.go
@@ -55,7 +55,7 @@ func RandomG1(r io.Reader) (*big.Int, *G1, error) {
 
 func (e *G1) String() string {
 	if e.p == nil {
-		e.p = newCurvePoint(nil)
+		return "bn256.G1" + newCurvePoint(nil).String()
 	}
 	return "bn256.G1" + e.p.String()
 }
@@ -179,7 +179,7 @@ func RandomG2(r io.Reader) (*big.Int, *G2, error) {
 
 func (e *G2) String() string {
 	if e.p == nil {
-		e.p = newTwistPoint(nil)
+		return "bn256.G2" + newTwistPoint(nil).String()
 	}
 	return "bn256.G2" + e.p.String()
 }
@@ -285,7 +285,7 @@ type GT struct {
 
 func (e *GT) String() string {
 	if e.p == nil {
-		e.p = newGFp12(nil)
+		return "bn256.GT" + newGFp12(nil).String()
 	}
 	return "bn256.GT" + e.p.String()
 }

--- a/bn256/bn256.go
+++ b/bn256/bn256.go
@@ -54,6 +54,9 @@ func RandomG1(r io.Reader) (*big.Int, *G1, error) {
 }
 
 func (e *G1) String() string {
+	if e.p == nil {
+		e.p = newCurvePoint(nil)
+	}
 	return "bn256.G1" + e.p.String()
 }
 
@@ -175,6 +178,9 @@ func RandomG2(r io.Reader) (*big.Int, *G2, error) {
 }
 
 func (e *G2) String() string {
+	if e.p == nil {
+		e.p = newTwistPoint(nil)
+	}
 	return "bn256.G2" + e.p.String()
 }
 
@@ -277,8 +283,11 @@ type GT struct {
 	p *gfP12
 }
 
-func (g *GT) String() string {
-	return "bn256.GT" + g.p.String()
+func (e *GT) String() string {
+	if e.p == nil {
+		e.p = newGFp12(nil)
+	}
+	return "bn256.GT" + e.p.String()
 }
 
 // ScalarMult sets e to a*k and then returns e.


### PR DESCRIPTION
Previously, when g.p == nil, String() crashed. In other method like Add(),
a point with g.p == nil is treated as an identity element.

Besides, the following code is the only way to get an identity element
outside the library: g := bn256.G1{}. In this situation, g.p == nil.

For example, the following code will crash:

package main

import (
	"fmt"
	"golang.org/x/crypto/bn256"
)

func main() {
	g := bn256.G1{}
	fmt.Println(g.String())
}