### PR TITLE
Export the PacketConn interface and Mux struct and add a NewMux func

### DIFF
--- a/ssh/channel.go
+++ b/ssh/channel.go
@@ -87,7 +87,7 @@ type Request struct {
 	Payload   []byte
 
 	ch  *channel
-	mux *mux
+	mux *Mux
 }
 
 // Reply sends a response to a request. It must be called for all requests
@@ -160,7 +160,7 @@ type channel struct {
 	maxIncomingPayload uint32
 	maxRemotePayload   uint32
 
-	mux *mux
+	mux *Mux
 
 	// decided is set to true if an accept or reject message has been sent
 	// (for outbound channels) or received (for inbound channels).
@@ -454,7 +454,7 @@ func (ch *channel) handlePacket(packet []byte) error {
 	return nil
 }
 
-func (m *mux) newChannel(chanType string, direction channelDirection, extraData []byte) *channel {
+func (m *Mux) newChannel(chanType string, direction channelDirection, extraData []byte) *channel {
 	ch := &channel{
 		remoteWin:        window{Cond: newCond()},
 		myWindow:         channelWindowSize,

--- a/ssh/channel.go
+++ b/ssh/channel.go
@@ -191,7 +191,7 @@ type channel struct {
 	windowMu sync.Mutex
 	myWindow uint32
 
-	// writeMu serializes calls to mux.conn.writePacket() and
+	// writeMu serializes calls to mux.conn.WritePacket() and
 	// protects sentClose and packetPool. This mutex must be
 	// different from windowMu, as writePacket can block if there
 	// is a key exchange pending.
@@ -212,7 +212,7 @@ func (ch *channel) writePacket(packet []byte) error {
 		return io.EOF
 	}
 	ch.sentClose = (packet[0] == msgChannelClose)
-	err := ch.mux.conn.writePacket(packet)
+	err := ch.mux.conn.WritePacket(packet)
 	ch.writeMu.Unlock()
 	return err
 }

--- a/ssh/client.go
+++ b/ssh/client.go
@@ -84,8 +84,8 @@ func NewClientConn(c net.Conn, addr string, config *ClientConfig) (Conn, <-chan 
 		c.Close()
 		return nil, nil, nil, fmt.Errorf("ssh: handshake failed: %v", err)
 	}
-	conn.mux = newMux(conn.transport)
-	return conn, conn.mux.incomingChannels, conn.mux.incomingRequests, nil
+	conn.Mux = newMux(conn.transport)
+	return conn, conn.Mux.incomingChannels, conn.Mux.incomingRequests, nil
 }
 
 // clientHandshake performs the client side key exchange. See RFC 4253 Section

--- a/ssh/connection.go
+++ b/ssh/connection.go
@@ -90,7 +90,7 @@ type connection struct {
 	sshConn
 
 	// The connection protocol.
-	*mux
+	*Mux
 }
 
 func (c *connection) Close() error {

--- a/ssh/mempipe_test.go
+++ b/ssh/mempipe_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-// An in-memory packetConn. It is safe to call Close and writePacket
+// An in-memory PacketConn. It is safe to call Close and WritePacket
 // from different goroutines.
 type memTransport struct {
 	eof     bool
@@ -20,7 +20,7 @@ type memTransport struct {
 	*sync.Cond
 }
 
-func (t *memTransport) readPacket() ([]byte, error) {
+func (t *memTransport) ReadPacket() ([]byte, error) {
 	t.Lock()
 	defer t.Unlock()
 	for {
@@ -53,7 +53,7 @@ func (t *memTransport) Close() error {
 	return err
 }
 
-func (t *memTransport) writePacket(p []byte) error {
+func (t *memTransport) WritePacket(p []byte) error {
 	t.write.Lock()
 	defer t.write.Unlock()
 	if t.write.eof {
@@ -66,7 +66,7 @@ func (t *memTransport) writePacket(p []byte) error {
 	return nil
 }
 
-func memPipe() (a, b packetConn) {
+func memPipe() (a, b PacketConn) {
 	t1 := memTransport{}
 	t2 := memTransport{}
 	t1.write = &t2
@@ -78,20 +78,20 @@ func memPipe() (a, b packetConn) {
 
 func TestMemPipe(t *testing.T) {
 	a, b := memPipe()
-	if err := a.writePacket([]byte{42}); err != nil {
-		t.Fatalf("writePacket: %v", err)
+	if err := a.WritePacket([]byte{42}); err != nil {
+		t.Fatalf("WritePacket: %v", err)
 	}
 	if err := a.Close(); err != nil {
 		t.Fatal("Close: ", err)
 	}
-	p, err := b.readPacket()
+	p, err := b.ReadPacket()
 	if err != nil {
-		t.Fatal("readPacket: ", err)
+		t.Fatal("ReadPacket: ", err)
 	}
 	if len(p) != 1 || p[0] != 42 {
 		t.Fatalf("got %v, want {42}", p)
 	}
-	p, err = b.readPacket()
+	p, err = b.ReadPacket()
 	if err != io.EOF {
 		t.Fatalf("got %v, %v, want EOF", p, err)
 	}

--- a/ssh/mux.go
+++ b/ssh/mux.go
@@ -86,7 +86,7 @@ func (c *chanList) dropAll() []*channel {
 // mux represents the state for the SSH connection protocol, which
 // multiplexes many channels onto a single packet transport.
 type mux struct {
-	conn     packetConn
+	conn     PacketConn
 	chanList chanList
 
 	incomingChannels chan NewChannel
@@ -113,7 +113,7 @@ func (m *mux) Wait() error {
 }
 
 // newMux returns a mux that runs over the given connection.
-func newMux(p packetConn) *mux {
+func newMux(p PacketConn) *mux {
 	m := &mux{
 		conn:             p,
 		incomingChannels: make(chan NewChannel, chanSize),
@@ -134,7 +134,7 @@ func (m *mux) sendMessage(msg interface{}) error {
 	if debugMux {
 		log.Printf("send global(%d): %#v", m.chanList.offset, msg)
 	}
-	return m.conn.writePacket(p)
+	return m.conn.WritePacket(p)
 }
 
 func (m *mux) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
@@ -212,7 +212,7 @@ func (m *mux) loop() {
 
 // onePacket reads and processes one packet.
 func (m *mux) onePacket() error {
-	packet, err := m.conn.readPacket()
+	packet, err := m.conn.ReadPacket()
 	if err != nil {
 		return err
 	}

--- a/ssh/mux_test.go
+++ b/ssh/mux_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func muxPair() (*mux, *mux) {
+func muxPair() (*Mux, *Mux) {
 	a, b := memPipe()
 
 	s := newMux(a)
@@ -22,7 +22,7 @@ func muxPair() (*mux, *mux) {
 
 // Returns both ends of a channel, and the mux for the 2nd
 // channel.
-func channelPair(t *testing.T) (*channel, *channel, *mux) {
+func channelPair(t *testing.T) (*channel, *channel, *Mux) {
 	c, s := muxPair()
 
 	res := make(chan *channel, 1)

--- a/ssh/mux_test.go
+++ b/ssh/mux_test.go
@@ -154,7 +154,7 @@ func TestMuxChannelOverflow(t *testing.T) {
 	marshalUint32(packet[5:], uint32(1))
 	packet[9] = 42
 
-	if err := writer.mux.conn.writePacket(packet); err != nil {
+	if err := writer.mux.conn.WritePacket(packet); err != nil {
 		t.Errorf("could not send packet")
 	}
 	if _, err := reader.SendRequest("hello", true, nil); err == nil {
@@ -432,7 +432,7 @@ func TestMuxInvalidRecord(t *testing.T) {
 	marshalUint32(packet[5:], 1)
 	packet[9] = 42
 
-	a.conn.writePacket(packet)
+	a.conn.WritePacket(packet)
 	go a.SendRequest("hello", false, nil)
 	// 'a' wrote an invalid packet, so 'b' has exited.
 	req, ok := <-b.incomingRequests
@@ -475,7 +475,7 @@ func TestMuxMaxPacketSize(t *testing.T) {
 	marshalUint32(packet[5:], uint32(len(large)))
 	packet[9] = 42
 
-	if err := a.mux.conn.writePacket(packet); err != nil {
+	if err := a.mux.conn.WritePacket(packet); err != nil {
 		t.Errorf("could not send packet")
 	}
 

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -184,7 +184,7 @@ func NewServerConn(c net.Conn, config *ServerConfig) (*ServerConn, <-chan NewCha
 		c.Close()
 		return nil, nil, nil, err
 	}
-	return &ServerConn{s, perms}, s.mux.incomingChannels, s.mux.incomingRequests, nil
+	return &ServerConn{s, perms}, s.Mux.incomingChannels, s.Mux.incomingRequests, nil
 }
 
 // signAndMarshal signs the data with the appropriate algorithm,
@@ -252,7 +252,7 @@ func (s *connection) serverHandshake(config *ServerConfig) (*Permissions, error)
 	if err != nil {
 		return nil, err
 	}
-	s.mux = newMux(s.transport)
+	s.Mux = newMux(s.transport)
 	return perms, err
 }
 

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -230,7 +230,7 @@ func (s *connection) serverHandshake(config *ServerConfig) (*Permissions, error)
 	s.sessionID = s.transport.getSessionID()
 
 	var packet []byte
-	if packet, err = s.transport.readPacket(); err != nil {
+	if packet, err = s.transport.ReadPacket(); err != nil {
 		return nil, err
 	}
 
@@ -244,7 +244,7 @@ func (s *connection) serverHandshake(config *ServerConfig) (*Permissions, error)
 	serviceAccept := serviceAcceptMsg{
 		Service: serviceUserAuth,
 	}
-	if err := s.transport.writePacket(Marshal(&serviceAccept)); err != nil {
+	if err := s.transport.WritePacket(Marshal(&serviceAccept)); err != nil {
 		return nil, err
 	}
 
@@ -337,7 +337,7 @@ userAuthLoop:
 				Message: "too many authentication failures",
 			}
 
-			if err := s.transport.writePacket(Marshal(discMsg)); err != nil {
+			if err := s.transport.WritePacket(Marshal(discMsg)); err != nil {
 				return nil, err
 			}
 
@@ -345,7 +345,7 @@ userAuthLoop:
 		}
 
 		var userAuthReq userAuthRequestMsg
-		if packet, err := s.transport.readPacket(); err != nil {
+		if packet, err := s.transport.ReadPacket(); err != nil {
 			if err == io.EOF {
 				return nil, &ServerAuthError{Errors: authErrs}
 			}
@@ -367,7 +367,7 @@ userAuthLoop:
 				bannerMsg := &userAuthBannerMsg{
 					Message: msg,
 				}
-				if err := s.transport.writePacket(Marshal(bannerMsg)); err != nil {
+				if err := s.transport.WritePacket(Marshal(bannerMsg)); err != nil {
 					return nil, err
 				}
 			}
@@ -467,7 +467,7 @@ userAuthLoop:
 						Algo:   algo,
 						PubKey: pubKeyData,
 					}
-					if err = s.transport.writePacket(Marshal(&okMsg)); err != nil {
+					if err = s.transport.WritePacket(Marshal(&okMsg)); err != nil {
 						return nil, err
 					}
 					continue userAuthLoop
@@ -527,12 +527,12 @@ userAuthLoop:
 			return nil, errors.New("ssh: no authentication methods configured but NoClientAuth is also false")
 		}
 
-		if err := s.transport.writePacket(Marshal(&failureMsg)); err != nil {
+		if err := s.transport.WritePacket(Marshal(&failureMsg)); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := s.transport.writePacket([]byte{msgUserAuthSuccess}); err != nil {
+	if err := s.transport.WritePacket([]byte{msgUserAuthSuccess}); err != nil {
 		return nil, err
 	}
 	return perms, nil
@@ -555,7 +555,7 @@ func (c *sshClientKeyboardInteractive) Challenge(user, instruction string, quest
 		prompts = appendBool(prompts, echos[i])
 	}
 
-	if err := c.transport.writePacket(Marshal(&userAuthInfoRequestMsg{
+	if err := c.transport.WritePacket(Marshal(&userAuthInfoRequestMsg{
 		Instruction: instruction,
 		NumPrompts:  uint32(len(questions)),
 		Prompts:     prompts,
@@ -563,7 +563,7 @@ func (c *sshClientKeyboardInteractive) Challenge(user, instruction string, quest
 		return nil, err
 	}
 
-	packet, err := c.transport.readPacket()
+	packet, err := c.transport.ReadPacket()
 	if err != nil {
 		return nil, err
 	}

--- a/ssh/transport.go
+++ b/ssh/transport.go
@@ -22,16 +22,16 @@ const (
 	tripledescbcID = "3des-cbc"
 )
 
-// packetConn represents a transport that implements packet based
+// PacketConn represents a transport that implements packet based
 // operations.
-type packetConn interface {
+type PacketConn interface {
 	// Encrypt and send a packet of data to the remote peer.
-	writePacket(packet []byte) error
+	WritePacket(packet []byte) error
 
 	// Read a packet from the connection. The read is blocking,
 	// i.e. if error is nil, then the returned byte slice is
 	// always non-empty.
-	readPacket() ([]byte, error)
+	ReadPacket() ([]byte, error)
 
 	// Close closes the write-side of the connection.
 	Close() error
@@ -109,7 +109,7 @@ func (t *transport) printPacket(p []byte, write bool) {
 }
 
 // Read and decrypt next packet.
-func (t *transport) readPacket() (p []byte, err error) {
+func (t *transport) ReadPacket() (p []byte, err error) {
 	for {
 		p, err = t.reader.readPacket(t.bufReader)
 		if err != nil {
@@ -165,7 +165,7 @@ func (s *connectionState) readPacket(r *bufio.Reader) ([]byte, error) {
 	return fresh, err
 }
 
-func (t *transport) writePacket(packet []byte) error {
+func (t *transport) WritePacket(packet []byte) error {
 	if debugTransport {
 		t.printPacket(packet, true)
 	}

--- a/ssh/transport_test.go
+++ b/ssh/transport_test.go
@@ -86,7 +86,7 @@ func TestTransportMaxPacketWrite(t *testing.T) {
 	buf := &closerBuffer{}
 	tr := newTransport(buf, rand.Reader, true)
 	huge := make([]byte, maxPacket+1)
-	err := tr.writePacket(huge)
+	err := tr.WritePacket(huge)
 	if err == nil {
 		t.Errorf("transport accepted write for a huge packet.")
 	}
@@ -104,7 +104,7 @@ func TestTransportMaxPacketReader(t *testing.T) {
 	buf.Write(huge)
 
 	tr := newTransport(buf, rand.Reader, true)
-	_, err := tr.readPacket()
+	_, err := tr.ReadPacket()
 	if err == nil {
 		t.Errorf("transport succeeded reading huge packet.")
 	} else if !strings.Contains(err.Error(), "large") {


### PR DESCRIPTION
This pull request replaces [#76](https://github.com/golang/crypto/pull/76) which added support for the OpenSSH ControlMaster protocol. Instead, this request exports the required internal structures and interfaces allowing an external package to make use of the `Mux` struct using their own `PacketConn`. The `NewMux` method returns the `incomingChannels` and `incomingRequests` chans which can be passed to `NewClient` after implementing the addition funcs in the `ConnMetadata` interface. 