### PR TITLE
Make sample code work on windows

### DIFF
--- a/ssh/terminal/util.go
+++ b/ssh/terminal/util.go
@@ -9,7 +9,7 @@
 //
 // Putting a terminal into raw mode is the most common requirement:
 //
-// 	oldState, err := terminal.MakeRaw(0)
+// 	oldState, err := terminal.MakeRaw(int(os.Stdin.Fd()))
 // 	if err != nil {
 // 	        panic(err)
 // 	}


### PR DESCRIPTION
On windows, the stdin fd is not 0.  This may saved windows newbies like me a lot of time.  Don't ask how I know :) 