### PR TITLE
acme/autocert: remove tempfile after dircache write failed

### DIFF
--- a/acme/autocert/cache.go
+++ b/acme/autocert/cache.go
@@ -119,7 +119,7 @@ func (d DirCache) Delete(ctx context.Context, name string) error {
 }
 
 // writeTempFile writes b to a temporary file, closes the file and returns its path.
-func (d DirCache) writeTempFile(prefix string, b []byte) (string, reterr error) {
+func (d DirCache) writeTempFile(prefix string, b []byte) (name string, reterr error) {
 	// TempFile uses 0600 permissions
 	f, err := ioutil.TempFile(string(d), prefix)
 	if err != nil {
@@ -131,7 +131,7 @@ func (d DirCache) writeTempFile(prefix string, b []byte) (string, reterr error) 
 		}
 	}()
 	if _, err := f.Write(b); err != nil {
-		reterr = f.Close()
+		f.Close()
 		return "", err
 	}
 	return f.Name(), f.Close()

--- a/acme/autocert/cache.go
+++ b/acme/autocert/cache.go
@@ -73,13 +73,11 @@ func (d DirCache) Put(ctx context.Context, name string, data []byte) error {
 	var err error
 	go func() {
 		var tmp string
-		defer func() {
-			os.Remove(tmp)
-			close(done)
-		}()
+		defer close(done)
 		if tmp, err = d.writeTempFile(name, data); err != nil {
 			return
 		}
+		defer os.Remove(tmp)
 		select {
 		case <-ctx.Done():
 			// Don't overwrite the file if the context was canceled.

--- a/acme/autocert/cache.go
+++ b/acme/autocert/cache.go
@@ -72,8 +72,8 @@ func (d DirCache) Put(ctx context.Context, name string, data []byte) error {
 	done := make(chan struct{})
 	var err error
 	go func() {
-		var tmp string
 		defer close(done)
+		var tmp string
 		if tmp, err = d.writeTempFile(name, data); err != nil {
 			return
 		}

--- a/acme/autocert/cache.go
+++ b/acme/autocert/cache.go
@@ -124,6 +124,7 @@ func (d DirCache) writeTempFile(prefix string, b []byte) (string, error) {
 	}
 	if _, err := f.Write(b); err != nil {
 		f.Close()
+		os.Remove(f.Name())
 		return "", err
 	}
 	return f.Name(), f.Close()

--- a/acme/autocert/cache.go
+++ b/acme/autocert/cache.go
@@ -119,14 +119,19 @@ func (d DirCache) Delete(ctx context.Context, name string) error {
 }
 
 // writeTempFile writes b to a temporary file, closes the file and returns its path.
-func (d DirCache) writeTempFile(prefix string, b []byte) (string, error) {
+func (d DirCache) writeTempFile(prefix string, b []byte) (string, reterr error) {
 	// TempFile uses 0600 permissions
 	f, err := ioutil.TempFile(string(d), prefix)
 	if err != nil {
 		return "", err
 	}
+	defer func() {
+		if reterr != nil {
+			os.Remove(f.Name())
+		}
+	}()
 	if _, err := f.Write(b); err != nil {
-		f.Close()
+		reterr = f.Close()
 		return "", err
 	}
 	return f.Name(), f.Close()

--- a/acme/autocert/cache_test.go
+++ b/acme/autocert/cache_test.go
@@ -47,12 +47,14 @@ func TestDirCache(t *testing.T) {
 	if _, err := os.Stat(name); err != nil {
 		t.Error(err)
 	}
-	tmp, err := filepath.Glob(name + "[^0-9]")
+
+	// test put deletes temp file
+	tmp, err := filepath.Glob(name + "?*")
 	if err != nil {
 		t.Error(err)
 	}
 	if tmp != nil {
-		t.Errorf("get %v; want nil", tmp)
+		t.Errorf("temp file exists: %s", tmp)
 	}
 
 	// test delete

--- a/acme/autocert/cache_test.go
+++ b/acme/autocert/cache_test.go
@@ -47,6 +47,13 @@ func TestDirCache(t *testing.T) {
 	if _, err := os.Stat(name); err != nil {
 		t.Error(err)
 	}
+	tmp, err := filepath.Glob(name + "[^0-9]")
+	if err != nil {
+		t.Error(err)
+	}
+	if tmp != nil {
+		t.Errorf("get %v; want nil", tmp)
+	}
 
 	// test delete
 	if err := cache.Delete(ctx, "dummy"); err != nil {


### PR DESCRIPTION
Per https://golang.org/pkg/io/ioutil/#TempFile description, caller should remove the file when no longer needed.
