### PR TITLE
fixed bug in util_windows.go

### DIFF
--- a/ssh/terminal/util_windows.go
+++ b/ssh/terminal/util_windows.go
@@ -94,7 +94,7 @@ func ReadPassword(fd int) ([]byte, error) {
 	defer windows.SetConsoleMode(windows.Handle(fd), old)
 
 	var h windows.Handle
-	p, _ := windows.GetCurrentProcess()
+	p := windows.GetCurrentProcess()
 	if err := windows.DuplicateHandle(p, windows.Handle(fd), p, &h, 0, false, windows.DUPLICATE_SAME_ACCESS); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
C:\Users\Admin\go\src\golang.org\x\crypto\ssh\terminal\util_windows.go:97:7: ass
ignment mismatch: 2 variables but "golang.org/x/sys/windows".GetCurrentProcess r
eturns 1 values

I fixed this bug