### PR TITLE
crypto/openpgp: added compression in Encrypt function

### DIFF
--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -334,8 +334,19 @@ func Encrypt(ciphertext io.Writer, to []*Entity, signed *Entity, hints *FileHint
 	if err != nil {
 		return
 	}
+	literaldata := payload
+	if algo := config.Compression(); algo != packet.CompressionNone {
+		var compConfig *packet.CompressionConfig
+		if config != nil {
+			compConfig = config.CompressionConfig
+		}
+		literaldata, err = packet.SerializeCompressed(payload, algo, compConfig)
+		if err != nil {
+			return
+		}
+	}
 
-	return writeAndSign(payload, candidateHashes, signed, hints, config)
+	return writeAndSign(literaldata, candidateHashes, signed, hints, config)
 }
 
 // Sign signs a message. The resulting WriteCloser must be closed after the


### PR DESCRIPTION
installed Golang version and architecture details : 
```
$ go env
GOARCH="amd64"
GOBIN=""
GOCACHE="/Users/Gaurav.k/Library/Caches/go-build"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="darwin"
GOOS="darwin"
GOPATH="/Users/Gaurav.k/Projects/GoProjects/"
GOPROXY=""
GORACE=""
GOROOT="/usr/local/Cellar/go/1.12.4/libexec"
GOTMPDIR=""
GOTOOLDIR="/usr/local/Cellar/go/1.12.4/libexec/pkg/tool/darwin_amd64"
GCCGO="gccgo"
CC="clang"
CXX="clang++"
CGO_ENABLED="1"
GOMOD=""
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/4_/703g62812t39dfmzfx4l7w3r0000gp/T/go-build267975514=/tmp/go-build -gno-record-gcc-switches -fno-common"
```
```
$ go version
go version go1.12.4 darwin/amd64
```

### What did you do? 
I'm trying to replicate following gpg command with `crypto/openpgp` package.
```
gpg --armor --output <outputfile > --cipher aes256 --compress-algo zip --s2k-digest-algo SHA256 --encrypt --recipient <userkey> --sign -u <privatekeyid>  <inputfile>
```
I'm using `crypto/openpgp` package to encrypt message with a public key and sign it with my private key. I'm using the `openpgp.Encrypt` method and passed following config as parameter: 
```
packetConfig := &packet.Config{
		DefaultCipher:          packet.CipherAES256,
		DefaultCompressionAlgo: packet.CompressionZIP,
		CompressionConfig: &packet.CompressionConfig{
			Level: flate.BestCompression,
		},
	}
```

### What did you expect to see?

I'm expected to see my plain text input message to be PGP encrypted and must have ZIP compression. 

### What did you see instead?
Message I get from `openpgp.Encrypt` method, is properly signed and encrypted but not compressed. 

### Resolution
Upon inspecting the Encrypt function and debugging the code, found out that it's not making use of compression config passed as argument anywhere in the flow. Made a change in write.go and added compression. After this change, the messages are properly encrypted and compressed. 







