### PR TITLE
Make default hash SHA-1 per RFC 4880 section 9.4

### DIFF
--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -280,7 +280,7 @@ func Encrypt(ciphertext io.Writer, to []*Entity, signed *Entity, hints *FileHint
 	// or hash functions, these are the ones that we assume that every
 	// implementation supports.
 	defaultCiphers := candidateCiphers[len(candidateCiphers)-1:]
-	defaultHashes := candidateHashes[len(candidateHashes)-1:]
+	defaultHashes := []uint8{hashToHashId(crypto.SHA1)}
 
 	encryptKeys := make([]Key, len(to))
 	for i := range to {
@@ -355,7 +355,7 @@ func Sign(output io.Writer, signed *Entity, hints *FileHints, config *packet.Con
 		hashToHashId(crypto.SHA1),
 		hashToHashId(crypto.RIPEMD160),
 	}
-	defaultHashes := candidateHashes[len(candidateHashes)-1:]
+	defaultHashes := []uint8{hashToHashId(crypto.SHA1)}
 	preferredHashes := signed.primaryIdentity().SelfSignature.PreferredHash
 	if len(preferredHashes) == 0 {
 		preferredHashes = defaultHashes


### PR DESCRIPTION
Motivation:
1. According to: https://tools.ietf.org/html/rfc4880#section-9.4, all implementation must support SHA1, however when no preferred hash algorithms are specified, current implementation defaults to RIPEMD160.
2. gpg 2.0.22 on Linux defaults to SHA1 when no preferred hash algorithms are specified, and as it's the de-facto standard implementation it's probably not a bad idea to do the same.
3. Golang's current implementation of RSA PKCS1 v1.5 signatures with RIPEMD160 hash function is broken, because RIPEMD160 has the wrong hash prefix (I will open a separate PR for this issue). So, defaulting to RIPEMD160 creates signatures that no other implementation of PGP can verify.