### PR TITLE
add cipher support for aes256-cbc aes192-cbc

### DIFF
--- a/ssh/cipher.go
+++ b/ssh/cipher.go
@@ -124,6 +124,8 @@ var cipherModes = map[string]*cipherMode{
 	// You should expect that an active attacker can recover plaintext if
 	// you do.
 	aes128cbcID: {16, aes.BlockSize, newAESCBCCipher},
+	aes192cbcID: {24, aes.BlockSize, newAESCBCCipher},
+	aes256cbcID: {32, aes.BlockSize, newAESCBCCipher},
 
 	// 3des-cbc is insecure and is not included in the default
 	// config.


### PR DESCRIPTION
rclone has added support for cipher aes256-cbc aes192-cbc in recent version. 

https://rclone.org/sftp/#sftp-use-insecure-cipher

However, they rely on GO crypto ssh module to work. 

This PR add cipher support for aes256-cbc aes192-cbc.