### PR TITLE
Added RSAKeypairBitSize to Manager in acme/autocert

### DIFF
--- a/acme/autocert/autocert.go
+++ b/acme/autocert/autocert.go
@@ -167,6 +167,12 @@ type Manager struct {
 	// The field value is passed to crypto/x509.CreateCertificateRequest
 	// in the template's ExtraExtensions field as is.
 	ExtraExtensions []pkix.Extension
+	
+	// RSAKeypairBitSize specifies the size of the RSA keypair.
+	//
+	// If the size that's specified is less than 2048 bits,
+	// RSAKeypairBitSize will be set to 2048.
+	RSAKeypairBitSize int
 
 	clientMu sync.Mutex
 	client   *acme.Client // initialized by acmeClient method
@@ -625,7 +631,11 @@ func (m *Manager) certState(ck certKey) (*certState, error) {
 		key crypto.Signer
 	)
 	if ck.isRSA {
-		key, err = rsa.GenerateKey(rand.Reader, 4096)
+		if m.RSAKeypairBitSize < 2048 {
+			m.RSAKeypairBitSize = 2048
+		}
+
+		key, err = rsa.GenerateKey(rand.Reader, m.RSAKeypairBitSize)
 	} else {
 		key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	}

--- a/acme/autocert/autocert.go
+++ b/acme/autocert/autocert.go
@@ -625,7 +625,7 @@ func (m *Manager) certState(ck certKey) (*certState, error) {
 		key crypto.Signer
 	)
 	if ck.isRSA {
-		key, err = rsa.GenerateKey(rand.Reader, 2048)
+		key, err = rsa.GenerateKey(rand.Reader, 4096)
 	} else {
 		key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	}


### PR DESCRIPTION
Currently, the bit size when generating an RSA keypair is fixed to 2048 bits. Adding RSAKeypairBitSize as a property on the Manager struct in acme/autocert offers the ability to use a higher bit size if desired.

This offers slightly increased security at the cost of slightly longer TLS handshake times and higher CPU usage. The bit size should also be configurable as there are providers that may not yet support 4096 bit RSA keypairs. 

Making it configurable now will also help in the future when 2048 bit RSA keypairs are no longer considered secure.