### PR TITLE
Use correct default hashes and default ciphers when no preferences given

### DIFF
--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -279,8 +279,8 @@ func Encrypt(ciphertext io.Writer, to []*Entity, signed *Entity, hints *FileHint
 	// In the event that a recipient doesn't specify any supported ciphers
 	// or hash functions, these are the ones that we assume that every
 	// implementation supports.
-	defaultCiphers := candidateCiphers[len(candidateCiphers)-1:]
-	defaultHashes := candidateHashes[len(candidateHashes)-1:]
+	defaultCiphers := candidateCiphers[:1]
+	defaultHashes := candidateHashes[:1]
 
 	encryptKeys := make([]Key, len(to))
 	for i := range to {
@@ -355,7 +355,7 @@ func Sign(output io.Writer, signed *Entity, hints *FileHints, config *packet.Con
 		hashToHashId(crypto.SHA1),
 		hashToHashId(crypto.RIPEMD160),
 	}
-	defaultHashes := candidateHashes[len(candidateHashes)-1:]
+	defaultHashes := candidateHashes[:1]
 	preferredHashes := signed.primaryIdentity().SelfSignature.PreferredHash
 	if len(preferredHashes) == 0 {
 		preferredHashes = defaultHashes


### PR DESCRIPTION
Per comments in config.go

> // DefaultHash is the default hash function to be used.
> // If zero, SHA-256 is used.
> DefaultHash crypto.
> // DefaultCipher is the cipher to be used.
> // If zero, AES-128 is used.
> DefaultCipher CipherFunction
> 

But instead we get RIPEMD160 and CAST5 if config is nil. Both are obsolete.
Fix https://github.com/golang/go/issues/37646