### PR TITLE
Use boolean tag (0x01) for boolean type.

### DIFF
--- a/cryptobyte/asn1.go
+++ b/cryptobyte/asn1.go
@@ -230,12 +230,12 @@ func (b *Builder) AddASN1(tag asn1.Tag, f BuilderContinuation) {
 
 // String
 
-// ReadASN1Boolean decodes an ASN.1 INTEGER and converts it to a boolean
+// ReadASN1Boolean decodes an ASN.1 BOOLEAN and converts it to a boolean
 // representation into out and advances. It reports whether the read
 // was successful.
 func (s *String) ReadASN1Boolean(out *bool) bool {
 	var bytes String
-	if !s.ReadASN1(&bytes, asn1.INTEGER) || len(bytes) != 1 {
+	if !s.ReadASN1(&bytes, asn1.BOOLEAN) || len(bytes) != 1 {
 		return false
 	}
 

--- a/cryptobyte/asn1_test.go
+++ b/cryptobyte/asn1_test.go
@@ -351,3 +351,24 @@ func TestAddASN1BigInt(t *testing.T) {
 		t.Errorf("unexpected bytes %v, want %v", &y, x)
 	}
 }
+
+func TestReadASN1Boolean(t *testing.T) {
+	testData := []struct {
+		in  []byte
+		ok  bool
+		out bool
+	}{
+		{[]byte{}, false, false},
+		{[]byte{0x01, 0x01, 0x00}, true, false},
+		{[]byte{0x01, 0x01, 0xff}, true, true},
+		{[]byte{0x01, 0x01, 0x01}, false, false},
+	}
+	for i, test := range testData {
+		in := String(test.in)
+		var out bool
+		ok := in.ReadASN1Boolean(&out)
+		if ok != test.ok || ok && (out != test.out) {
+			t.Errorf("#%d: in.ReadASN1Boolean() = %v, want %v; out = %v, want %v", i, ok, test.ok, out, test.out)
+		}
+	}
+}


### PR DESCRIPTION
Fix for problem with ReadASN1Boolean, which uses invalid tag (Integer / 0x02) when trying to read boolean value. This is a fix for the one case mentioned in "x/crypto/cryptobyte: cannot read boolean values #26565"
This is specified in ITU-T X.690, section 8.2, with DER additions specified in 11.1.