### PR TITLE
x/crypto/ssh: known_host comments with spaces break on marker lines

### DIFF
--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -150,7 +150,7 @@ func ParseKnownHosts(in []byte) (marker string, hosts []string, pubKey PublicKey
 		// Strip out the beginning of the known_host key.
 		// This is either an optional marker or a (set of) hostname(s).
 		keyFields := bytes.Fields(in)
-		if len(keyFields) < 3 || len(keyFields) > 5 {
+		if len(keyFields) < 3 {
 			return "", nil, nil, "", nil, errors.New("ssh: invalid entry in known_hosts data")
 		}
 

--- a/ssh/keys_test.go
+++ b/ssh/keys_test.go
@@ -478,6 +478,36 @@ var knownHostsParseTests = []struct {
 
 		"", "", nil, "",
 	},
+	{
+		"@marker \tlocalhost,[host2:123]\tssh-rsa aabbccdd comment comment",
+		"short read",
+
+		"", "", nil, "",
+	},
+	{
+		"@marker \tlocalhost,[host2:123]\tssh-rsa {RSAPUB}\tcomment comment\r\n",
+		"",
+
+		"marker", "comment comment", []string{"localhost", "[host2:123]"}, "",
+	},
+	{
+		"@marker \tlocalhost,[host2:123]\tssh-rsa {RSAPUB}\tcomment comment\r\nthe rest",
+		"",
+
+		"marker", "comment comment", []string{"localhost", "[host2:123]"}, "the rest",
+	},
+	{
+		"@marker localhost",
+		"invalid entry in known_hosts data",
+
+		"", "", nil, "",
+	},
+	{
+		"localhost\tssh-rsa",
+		"invalid entry in known_hosts data",
+
+		"", "", nil, "",
+	},
 }
 
 func TestKnownHostsParsing(t *testing.T) {


### PR DESCRIPTION
### What version of Go are you using (`go version`)?

<pre>
$ go version
go version go1.14.2 darwin/amd64
</pre>

### Does this issue reproduce with the latest release?

Yes.

### What operating system and processor architecture are you using (`go env`)?

<details><summary><code>go env</code> Output</summary><br><pre>
$ go env
GO111MODULE=""
GOARCH="amd64"
GOBIN=""
GOCACHE="/Users/skemper/Library/Caches/go-build"
GOENV="/Users/skemper/Library/Application Support/go/env"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="darwin"
GOINSECURE=""
GONOPROXY=""
GONOSUMDB=""
GOOS="darwin"
GOPATH="/Users/skemper/Code/go"
GOPRIVATE=""
GOPROXY="https://proxy.golang.org,direct"
GOROOT="/usr/local/Cellar/go/1.14.2_1/libexec"
GOSUMDB="sum.golang.org"
GOTMPDIR=""
GOTOOLDIR="/usr/local/Cellar/go/1.14.2_1/libexec/pkg/tool/darwin_amd64"
GCCGO="gccgo"
AR="ar"
CC="clang"
CXX="clang++"
CGO_ENABLED="1"
GOMOD="/Users/skemper/Code/go/src/github.com/golang/crypto/go.mod"
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/var/folders/6c/yshyrn911ln2jxvm4l1_vznwslv63v/T/go-build928041994=/tmp/go-build -gno-record-gcc-switches -fno-common"
</pre></details>

### What did you do?

When calling `ssh.ParseKnownHosts()`, I gave it a known_hosts line which contained both an `@marker` directive, as well as a comment which included spaces.

`@cert-authority * ssh-rsa AAAABunchOfStuff Test Comment`

### What did you expect to see?

I expected `ssh.ParseKnownHosts()` to return a parsed version of the line, with the comment "Test Comment".

### What did you see instead?

`err` was filled in, with "ssh: invalid entry in known_hosts data."  This happens because the function checks if there are more than 5 fields in the line, which is an incorrect check in this scenario.  Since we're still parsing the entire line, we can't put an upper limit on the number of spaces as comments may contain spaces.  This fact is already properly respected by ParseAuthorizedKey, which is called later on.

It appears this wasn't caught by the existing tests because they either use comments with just a single space, or don't test the combination of markers and comments-with-spaces.  I've added a few new tests to compensate.