### PR TITLE
acme/autocert: include the domain in the SAN of the CSR

### DIFF
--- a/acme/autocert/autocert.go
+++ b/acme/autocert/autocert.go
@@ -1133,11 +1133,11 @@ func (s *certState) tlscert() (*tls.Certificate, error) {
 	}, nil
 }
 
-// certRequest generates a CSR for the given common name cn and optional SANs.
-func certRequest(key crypto.Signer, cn string, ext []pkix.Extension, san ...string) ([]byte, error) {
+// certRequest generates a CSR for the given common name.
+func certRequest(key crypto.Signer, name string, ext []pkix.Extension) ([]byte, error) {
 	req := &x509.CertificateRequest{
-		Subject:         pkix.Name{CommonName: cn},
-		DNSNames:        san,
+		Subject:         pkix.Name{CommonName: name},
+		DNSNames:        []string{name},
 		ExtraExtensions: ext,
 	}
 	return x509.CreateCertificateRequest(rand.Reader, req, key)

--- a/acme/autocert/autocert_test.go
+++ b/acme/autocert/autocert_test.go
@@ -1097,7 +1097,7 @@ func TestCertRequest(t *testing.T) {
 		Id:    asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1},
 		Value: []byte("dummy"),
 	}
-	b, err := certRequest(key, "example.org", []pkix.Extension{ext}, "san.example.org")
+	b, err := certRequest(key, "example.org", []pkix.Extension{ext})
 	if err != nil {
 		t.Fatalf("certRequest: %v", err)
 	}


### PR DESCRIPTION
More compliant with the spec and allows autocert to work
with Pebble (see letsencrypt/pebble#304).

Fixes golang/go#39746.