### PR TITLE
x/crypto/blake2s: Allow computing variable-length digests.

### DIFF
--- a/blake2s/blake2s.go
+++ b/blake2s/blake2s.go
@@ -66,6 +66,15 @@ func New128(key []byte) (hash.Hash, error) {
 	return newDigest(Size128, key)
 }
 
+// New returns a new hash.Hash computing the BLAKE2s checksum with a hashSize
+// long output.
+func New(hashSize int, key []byte) (hash.Hash, error) {
+	if hashSize < 1 || hashSize > 32 {
+		return nil, errors.New("blake2s: hash size must be between 1 and 32 bytes")
+	}
+	return newDigest(hashSize, key)
+}
+
 func newDigest(hashSize int, key []byte) (*digest, error) {
 	if len(key) > Size {
 		return nil, errKeySize


### PR DESCRIPTION
Current implementation provides only XOF-based method for
digest size other than 16 or 32 bytes. This commit allows
digest size between 1 and 32 bytes, as defined by the BLAKE2s
paper.

Fixes #36429

Signed-off-by: Jiří Keresteš <jiri@kerestes.cz>