### PR TITLE
crypto/ssh/terminal: add Terminal.GetPrompt method

### DIFF
--- a/ssh/terminal/terminal.go
+++ b/ssh/terminal/terminal.go
@@ -806,6 +806,11 @@ func (t *Terminal) SetPrompt(prompt string) {
 	t.prompt = []rune(prompt)
 }
 
+// GetPrompt returns the current prompt.
+func (t *Terminal) GetPrompt() string {
+	return string(t.prompt)
+}
+
 func (t *Terminal) clearAndRepaintLinePlusNPrevious(numPrevLines int) {
 	// Move cursor to column zero at the start of the line.
 	t.move(t.cursorY, 0, t.cursorX, 0)

--- a/ssh/terminal/terminal_test.go
+++ b/ssh/terminal/terminal_test.go
@@ -424,6 +424,15 @@ func TestMakeRawState(t *testing.T) {
 	}
 }
 
+func TestGetPrompt(t *testing.T) {
+	c := &MockTerminal{}
+	ss := NewTerminal(c, "prompt")
+	p := ss.GetPrompt()
+	if p != "prompt" {
+		t.Fatalf("failed to read prompt, got %s", p)
+	}
+}
+
 func TestOutputNewlines(t *testing.T) {
 	// \n should be changed to \r\n in terminal output.
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
The Terminal struct has no existing way of reading the value of the current
prompt. When updating the prompt it's sometimes necessary to know what the
existing value is. For example, when something needs to be appended/removed from
the existing prompt. `Terminal.prompt` is a private field and is set using
`SetPrompt`. This PR also adds a relevant test.