### PR TITLE
Add function to allow cross-certification of signing subkeys

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -578,7 +578,7 @@ func NewEntity(name, comment, email string, config *packet.Config) (*Entity, err
 	}
 	e.Subkeys[0].PublicKey.IsSubkey = true
 	e.Subkeys[0].PrivateKey.IsSubkey = true
-	err = e.Subkeys[0].Sig.SignKey(e.Subkeys[0].PublicKey, e.PrivateKey, config)
+	err = e.Subkeys[0].Sig.SignSubKey(e.Subkeys[0].PublicKey, e.PrivateKey, config)
 	if err != nil {
 		return nil, err
 	}
@@ -613,7 +613,13 @@ func (e *Entity) SerializePrivate(w io.Writer, config *packet.Config) (err error
 		if err != nil {
 			return
 		}
-		err = subkey.Sig.SignKey(subkey.PublicKey, e.PrivateKey, config)
+		if subkey.Sig.FlagsValid && subkey.Sig.FlagSign {
+			err = subkey.Sig.EmbeddedSignature.SignMasterKey(e.PrimaryKey, subkey.PrivateKey, config)
+			if err != nil {
+				return
+			}
+		}
+		err = subkey.Sig.SignSubKey(subkey.PublicKey, e.PrivateKey, config)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Adds
-----
* The `Signature.SignMasterKey()` function to allow subkeys to embed signature [cross-certifying](https://www.gnupg.org/faq/subkey-cross-certify.html) the master key.
* The `Signature.SignSubKey()` function which should now be used instead of `Signature.SignKey()` in order to make differences clearer, although the latter is still preserved for backwards-compatibility.

Refactored
-----------
* The `Signature.Serialize()` function has now decomposed its latter half into a `Signature.serializeWithoutHeaders()` function to allow for [embedding signatures as a complete packet body](https://tools.ietf.org/html/rfc4880#section-5.2.3.26).

I would be remiss if I did not mention that this PR borrowed inspiration from [another PR](https://go-review.googlesource.com/c/crypto/+/161817/), except that this PR adds the bare minimum needed for a signing subkey to embed a cross-certification.

Signed-off-by: Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com>