### PR TITLE
Allow signing with any private key including subkeys

### DIFF
--- a/openpgp/packet/config.go
+++ b/openpgp/packet/config.go
@@ -46,6 +46,11 @@ type Config struct {
 	// RSABits is the number of bits in new RSA keys made with NewEntity.
 	// If zero, then 2048 bit keys are created.
 	RSABits int
+	// SigLifetimeSecs is the number of seconds after the signature creation
+	// time that the signature expires.  If this is not present or has a value
+	// of zero, it never expires.
+	// https://tools.ietf.org/html/rfc4880#section-5.2.3.10
+	SigLifetimeSecs uint32
 }
 
 func (c *Config) Random() io.Reader {

--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -6,7 +6,6 @@ package openpgp
 
 import (
 	"crypto"
-	"fmt"
 	"hash"
 	"io"
 	"strconv"
@@ -18,72 +17,63 @@ import (
 	"golang.org/x/crypto/openpgp/s2k"
 )
 
-// DetachSign signs message with the private key (which must already have been
-// decrypted) from signer (which must be a *Entity, *Subkey, or *Key) and
-// writes the signature to w. If config is nil, sensible defaults will be
-// used.
-func DetachSign(w io.Writer, signer interface{}, message io.Reader, config *packet.Config) error {
-	privateKey, err := getPrivateKey(signer)
-	if err != nil {
-		return err
-	}
-	return detachSign(w, privateKey, message, packet.SigTypeBinary, config)
+// DetachSign signs message with the private key from signer (which must
+// already have been decrypted) and writes the signature to w.
+// If config is nil, sensible defaults will be used.
+func DetachSign(w io.Writer, signer *Entity, message io.Reader, config *packet.Config) error {
+	return detachSign(w, signer.PrivateKey, message, packet.SigTypeBinary, config)
 }
 
-// ArmoredDetachSign signs message with the private key (which must already
-// have been decrypted) from signer (which must be a *Entity, *Subkey, or
-// *Key) and writes an armored signature to w. If config is nil, sensible
-// defaults will be used.
-func ArmoredDetachSign(w io.Writer, signer interface{}, message io.Reader, config *packet.Config) (err error) {
-	privateKey, err := getPrivateKey(signer)
-	if err != nil {
-		return err
-	}
-	return armoredDetachSign(w, privateKey, message, packet.SigTypeBinary, config)
+// ArmoredDetachSign signs message with the private key from signer (which
+// must already have been decrypted) and writes an armored signature to w.
+// If config is nil, sensible defaults will be used.
+func ArmoredDetachSign(w io.Writer, signer *Entity, message io.Reader, config *packet.Config) (err error) {
+	return armoredDetachSign(w, signer.PrivateKey, message, packet.SigTypeBinary, config)
 }
 
 // DetachSignText signs message (after canonicalising the line endings) with
-// the private key (which must already have been decrypted) from signer (which
-// must be a *Entity, *Subkey, or *Key) and writes the signature to w. If
-// config is nil, sensible defaults will be used.
-func DetachSignText(w io.Writer, signer interface{}, message io.Reader, config *packet.Config) error {
-	privateKey, err := getPrivateKey(signer)
-	if err != nil {
-		return err
-	}
-	return detachSign(w, privateKey, message, packet.SigTypeText, config)
+// the private key from signer (which must already have been decrypted) and
+// writes the signature to w.
+// If config is nil, sensible defaults will be used.
+func DetachSignText(w io.Writer, signer *Entity, message io.Reader, config *packet.Config) error {
+	return detachSign(w, signer.PrivateKey, message, packet.SigTypeText, config)
 }
 
 // ArmoredDetachSignText signs message (after canonicalising the line endings)
-// with the private key (which must already have been decrypted) from signer
-// (which must be a *Entity, *Subkey, or *Key) and writes an armored signature
-// to w. If config is nil, sensible defaults will be used.
-func ArmoredDetachSignText(w io.Writer, signer interface{}, message io.Reader, config *packet.Config) error {
-	privateKey, err := getPrivateKey(signer)
-	if err != nil {
-		return err
-	}
-	return armoredDetachSign(w, privateKey, message, packet.SigTypeText, config)
+// with the private key from signer (which must already have been decrypted)
+// and writes an armored signature to w.
+// If config is nil, sensible defaults will be used.
+func ArmoredDetachSignText(w io.Writer, signer *Entity, message io.Reader, config *packet.Config) error {
+	return armoredDetachSign(w, signer.PrivateKey, message, packet.SigTypeText, config)
 }
 
-func getPrivateKey(i interface{}) (privateKey *packet.PrivateKey, err error) {
-	entity, ok := i.(*Entity)
-	if ok {
-		privateKey = entity.PrivateKey
-	} else {
-		subkey, ok := i.(*Subkey)
-		if ok {
-			privateKey = subkey.PrivateKey
-		} else {
-			key, ok := i.(*Key)
-			if ok {
-				privateKey = key.PrivateKey
-			} else {
-				err = fmt.Errorf("write: %T not *Entity, *Subkey, or *Key", i)
-			}
-		}
-	}
-	return
+// NewDetachSign signs message with the privateKey (which must already have been
+// decrypted) and writes the signature to w. If config is nil, sensible
+// defaults will be used.
+func NewDetachSign(w io.Writer, privateKey *packet.PrivateKey, message io.Reader, config *packet.Config) error {
+	return detachSign(w, privateKey, message, packet.SigTypeBinary, config)
+}
+
+// NewArmoredDetachSign signs message with the privateKey (which must already
+// have been decrypted) and writes an armored signature to w. If config is
+// nil, sensible defaults will be used.
+func NewArmoredDetachSign(w io.Writer, privateKey *packet.PrivateKey, message io.Reader, config *packet.Config) (err error) {
+	return armoredDetachSign(w, privateKey, message, packet.SigTypeBinary, config)
+}
+
+// NewDetachSignText signs message (after canonicalising the line endings)
+// with the privateKey (which must already have been decrypted) and writes
+// the signature to w. If config is nil, sensible defaults will be used.
+func NewDetachSignText(w io.Writer, privateKey *packet.PrivateKey, message io.Reader, config *packet.Config) error {
+	return detachSign(w, privateKey, message, packet.SigTypeText, config)
+}
+
+// NewArmoredDetachSignText signs message (after canonicalising the line
+// endings) with the privateKey (which must already have been decrypted) and
+// writes an armored signature to w. If config is nil, sensible defaults will
+// be used.
+func NewArmoredDetachSignText(w io.Writer, privateKey *packet.PrivateKey, message io.Reader, config *packet.Config) error {
+	return armoredDetachSign(w, privateKey, message, packet.SigTypeText, config)
 }
 
 func armoredDetachSign(w io.Writer, privateKey *packet.PrivateKey, message io.Reader, sigType packet.SignatureType, config *packet.Config) (err error) {

--- a/openpgp/write.go
+++ b/openpgp/write.go
@@ -6,6 +6,7 @@ package openpgp
 
 import (
 	"crypto"
+	"fmt"
 	"hash"
 	"io"
 	"strconv"
@@ -17,62 +18,101 @@ import (
 	"golang.org/x/crypto/openpgp/s2k"
 )
 
-// DetachSign signs message with the private key from signer (which must
-// already have been decrypted) and writes the signature to w.
-// If config is nil, sensible defaults will be used.
-func DetachSign(w io.Writer, signer *Entity, message io.Reader, config *packet.Config) error {
-	return detachSign(w, signer, message, packet.SigTypeBinary, config)
+// DetachSign signs message with the private key (which must already have been
+// decrypted) from signer (which must be a *Entity, *Subkey, or *Key) and
+// writes the signature to w. If config is nil, sensible defaults will be
+// used.
+func DetachSign(w io.Writer, signer interface{}, message io.Reader, config *packet.Config) error {
+	privateKey, err := getPrivateKey(signer)
+	if err != nil {
+		return err
+	}
+	return detachSign(w, privateKey, message, packet.SigTypeBinary, config)
 }
 
-// ArmoredDetachSign signs message with the private key from signer (which
-// must already have been decrypted) and writes an armored signature to w.
-// If config is nil, sensible defaults will be used.
-func ArmoredDetachSign(w io.Writer, signer *Entity, message io.Reader, config *packet.Config) (err error) {
-	return armoredDetachSign(w, signer, message, packet.SigTypeBinary, config)
+// ArmoredDetachSign signs message with the private key (which must already
+// have been decrypted) from signer (which must be a *Entity, *Subkey, or
+// *Key) and writes an armored signature to w. If config is nil, sensible
+// defaults will be used.
+func ArmoredDetachSign(w io.Writer, signer interface{}, message io.Reader, config *packet.Config) (err error) {
+	privateKey, err := getPrivateKey(signer)
+	if err != nil {
+		return err
+	}
+	return armoredDetachSign(w, privateKey, message, packet.SigTypeBinary, config)
 }
 
 // DetachSignText signs message (after canonicalising the line endings) with
-// the private key from signer (which must already have been decrypted) and
-// writes the signature to w.
-// If config is nil, sensible defaults will be used.
-func DetachSignText(w io.Writer, signer *Entity, message io.Reader, config *packet.Config) error {
-	return detachSign(w, signer, message, packet.SigTypeText, config)
+// the private key (which must already have been decrypted) from signer (which
+// must be a *Entity, *Subkey, or *Key) and writes the signature to w. If
+// config is nil, sensible defaults will be used.
+func DetachSignText(w io.Writer, signer interface{}, message io.Reader, config *packet.Config) error {
+	privateKey, err := getPrivateKey(signer)
+	if err != nil {
+		return err
+	}
+	return detachSign(w, privateKey, message, packet.SigTypeText, config)
 }
 
 // ArmoredDetachSignText signs message (after canonicalising the line endings)
-// with the private key from signer (which must already have been decrypted)
-// and writes an armored signature to w.
-// If config is nil, sensible defaults will be used.
-func ArmoredDetachSignText(w io.Writer, signer *Entity, message io.Reader, config *packet.Config) error {
-	return armoredDetachSign(w, signer, message, packet.SigTypeText, config)
+// with the private key (which must already have been decrypted) from signer
+// (which must be a *Entity, *Subkey, or *Key) and writes an armored signature
+// to w. If config is nil, sensible defaults will be used.
+func ArmoredDetachSignText(w io.Writer, signer interface{}, message io.Reader, config *packet.Config) error {
+	privateKey, err := getPrivateKey(signer)
+	if err != nil {
+		return err
+	}
+	return armoredDetachSign(w, privateKey, message, packet.SigTypeText, config)
 }
 
-func armoredDetachSign(w io.Writer, signer *Entity, message io.Reader, sigType packet.SignatureType, config *packet.Config) (err error) {
+func getPrivateKey(i interface{}) (privateKey *packet.PrivateKey, err error) {
+	entity, ok := i.(*Entity)
+	if ok {
+		privateKey = entity.PrivateKey
+	} else {
+		subkey, ok := i.(*Subkey)
+		if ok {
+			privateKey = subkey.PrivateKey
+		} else {
+			key, ok := i.(*Key)
+			if ok {
+				privateKey = key.PrivateKey
+			} else {
+				err = fmt.Errorf("write: %T not *Entity, *Subkey, or *Key", i)
+			}
+		}
+	}
+	return
+}
+
+func armoredDetachSign(w io.Writer, privateKey *packet.PrivateKey, message io.Reader, sigType packet.SignatureType, config *packet.Config) (err error) {
 	out, err := armor.Encode(w, SignatureType, nil)
 	if err != nil {
 		return
 	}
-	err = detachSign(out, signer, message, sigType, config)
+	err = detachSign(out, privateKey, message, sigType, config)
 	if err != nil {
 		return
 	}
 	return out.Close()
 }
 
-func detachSign(w io.Writer, signer *Entity, message io.Reader, sigType packet.SignatureType, config *packet.Config) (err error) {
-	if signer.PrivateKey == nil {
+func detachSign(w io.Writer, privateKey *packet.PrivateKey, message io.Reader, sigType packet.SignatureType, config *packet.Config) (err error) {
+	if privateKey == nil {
 		return errors.InvalidArgumentError("signing key doesn't have a private key")
 	}
-	if signer.PrivateKey.Encrypted {
+	if privateKey.Encrypted {
 		return errors.InvalidArgumentError("signing key is encrypted")
 	}
 
 	sig := new(packet.Signature)
 	sig.SigType = sigType
-	sig.PubKeyAlgo = signer.PrivateKey.PubKeyAlgo
+	sig.PubKeyAlgo = privateKey.PubKeyAlgo
 	sig.Hash = config.Hash()
 	sig.CreationTime = config.Now()
-	sig.IssuerKeyId = &signer.PrivateKey.KeyId
+	sig.SigLifetimeSecs = &config.SigLifetimeSecs
+	sig.IssuerKeyId = &privateKey.KeyId
 
 	h, wrappedHash, err := hashForSignature(sig.Hash, sig.SigType)
 	if err != nil {
@@ -80,7 +120,7 @@ func detachSign(w io.Writer, signer *Entity, message io.Reader, sigType packet.S
 	}
 	io.Copy(wrappedHash, message)
 
-	err = sig.Sign(h, signer.PrivateKey, config)
+	err = sig.Sign(h, privateKey, config)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Adds
-----
* Add `NewDetachSign*()`, `NewArmoredDetachSign*()` to allow subkeys, not just master keys, to sign.
* Allow signatures to expire using `Config.SigLifetimeSecs`.

Signed-off-by: Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com>