### PR TITLE
openpgp: parse notation data in signatures.

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -424,7 +424,10 @@ func addUserID(e *Entity, packets *packet.Reader, pkt *packet.UserId) error {
 			if err = e.PrimaryKey.VerifyUserIdSignature(pkt.Id, e.PrimaryKey, sig); err != nil {
 				return errors.StructuralError("user ID self-signature invalid: " + err.Error())
 			}
-			identity.SelfSignature = sig
+			if identity.SelfSignature == nil || sig.CreationTime.After(identity.SelfSignature.CreationTime) {
+				identity.SelfSignature = sig
+			}
+
 			e.Identities[pkt.Id] = identity
 		} else {
 			identity.Signatures = append(identity.Signatures, sig)

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -13,6 +13,7 @@ import (
 	"encoding/binary"
 	"hash"
 	"io"
+	"io/ioutil"
 	"math/big"
 	"strconv"
 	"time"
@@ -56,6 +57,7 @@ type Signature struct {
 	PreferredSymmetric, PreferredHash, PreferredCompression []uint8
 	IssuerKeyId                                             *uint64
 	IsPrimaryId                                             *bool
+	NotationData                                            map[string][]string
 
 	// FlagsValid is set if any flags were given. See RFC 4880, section
 	// 5.2.3.21 for details.
@@ -198,6 +200,7 @@ const (
 	keyExpirationSubpacket       signatureSubpacketType = 9
 	prefSymmetricAlgosSubpacket  signatureSubpacketType = 11
 	issuerSubpacket              signatureSubpacketType = 16
+	notationDataSubpacket        signatureSubpacketType = 20
 	prefHashAlgosSubpacket       signatureSubpacketType = 21
 	prefCompressionSubpacket     signatureSubpacketType = 22
 	primaryUserIdSubpacket       signatureSubpacketType = 25
@@ -297,6 +300,22 @@ func parseSignatureSubpacket(sig *Signature, subpacket []byte, isHashed bool) (r
 		}
 		sig.IssuerKeyId = new(uint64)
 		*sig.IssuerKeyId = binary.BigEndian.Uint64(subpacket)
+	case notationDataSubpacket:
+		// Notation data, section 5.2.3.16
+		buf := bytes.NewBuffer(subpacket)
+		// The first 4 bytes are for unused flags.
+		io.CopyN(ioutil.Discard, buf, 4)
+
+		keyLength := binary.BigEndian.Uint16(buf.Next(2))
+		valueLength := binary.BigEndian.Uint16(buf.Next(2))
+
+		key := string(buf.Next(int(keyLength)))
+		value := string(buf.Next(int(valueLength)))
+
+		if sig.NotationData == nil {
+			sig.NotationData = make(map[string][]string)
+		}
+		sig.NotationData[key] = append(sig.NotationData[key], value)
 	case prefHashAlgosSubpacket:
 		// Preferred hash algorithms, section 5.2.3.8
 		if !isHashed {


### PR DESCRIPTION
This change adds the ability to parse notation data packets in signature data. This is an alternative PR to one submitted by @ralt. Notation data consists of key-value pairs where the same key can be repeated for multiple values much like HTTP get parameters. In the other implementation it loses values where the key has been repeated.

I have also made a change in how it handles the self signature to only keep the most recent one. The current implementation will keep the last parsed version which isn't always the case.

To demonstrate the code I have setup this playground: https://play.golang.org/p/1x9kWh7Jp7T