### PR TITLE
openpgp/signature: set critical flag on signature subpackets

### DIFF
--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -446,6 +446,9 @@ func serializeSubpackets(to []byte, subpackets []outputSubpacket, hashed bool) {
 		if subpacket.hashed == hashed {
 			n := serializeSubpacketLength(to, len(subpacket.contents)+1)
 			to[n] = byte(subpacket.subpacketType)
+			if subpacket.isCritical {
+				to[n] |= 0x80
+			}
 			to = to[1+n:]
 			n = copy(to, subpacket.contents)
 			to = to[n:]


### PR DESCRIPTION
The signature subpackets are correctly setting the isCritical field to
true when an expiry date for a new signature is defined. This commit
changes the serializeSubpackets function to take this field into account
and set the critical bit accordingly.