### PR TITLE
openpgp: enable signing using a subkey that does not have the primary key private material

### DIFF
--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -117,6 +117,11 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 		if s2kType == 254 {
 			pk.sha1Checksum = true
 		}
+		if pk.cipher == 0 {
+			// http://www.iana.org/assignments/pgp-parameters/pgp-parameters.xhtml#pgp-parameters-12
+			// 0 = Plaintext or unencrypted data
+			pk.Encrypted = false
+		}
 	default:
 		return errors.UnsupportedError("deprecated s2k function in private key")
 	}
@@ -138,7 +143,7 @@ func (pk *PrivateKey) parse(r io.Reader) (err error) {
 		return
 	}
 
-	if !pk.Encrypted {
+	if !pk.Encrypted && len(pk.encryptedData) > 0 {
 		return pk.parsePrivateKey(pk.encryptedData)
 	}
 

--- a/openpgp/s2k/s2k_test.go
+++ b/openpgp/s2k/s2k_test.go
@@ -71,6 +71,8 @@ func TestIterated(t *testing.T) {
 var parseTests = []struct {
 	spec, in, out string
 }{
+	/* gnu-dummy */
+	{"0000", "hello", "00000000"},
 	/* Simple with SHA1 */
 	{"0002", "hello", "aaf4c61d"},
 	/* Salted with SHA1 */


### PR DESCRIPTION
This addresses issue https://github.com/golang/go/issues/23226 which allows users to follow the best practice of keeping their primary key offline. 
https://riseup.net/en/security/message-security/openpgp/best-practices#have-a-separate-subkey-for-signing

closes: https://github.com/golang/go/issues/13605
closes: https://github.com/golang/go/issues/23226
closes: https://github.com/golang/go/issues/9312