### PR TITLE
openpgp/packet: fix serialisation order of a RSA private key

### DIFF
--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -213,11 +213,11 @@ func serializeRSAPrivateKey(w io.Writer, priv *rsa.PrivateKey) error {
 	if err != nil {
 		return err
 	}
-	err = writeBig(w, priv.Primes[1])
+	err = writeBig(w, priv.Primes[0])
 	if err != nil {
 		return err
 	}
-	err = writeBig(w, priv.Primes[0])
+	err = writeBig(w, priv.Primes[1])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fix makes the serialisation/deserialisation round-trip produce keys that stay equals, according to `rsa.PrivateKey.Equal`.

As far as I understand this serialization problem isn't a security issue as illustrated by the [test that perform this round-trip then sign some data](https://github.com/golang/crypto/blob/master/openpgp/packet/private_key_test.go#L76-L118). This means that the keys were equivalent, but not strictly equal.

This issue is illustrated by the following test:
```go
func TestRoundTripRSAPrivateKey(t *testing.T) {
	rsaPriv, err := rsa.GenerateKey(rand.Reader, 2048)
	if err != nil {
		t.Fatal(err)
	}

	var buf bytes.Buffer
	if err := NewRSAPrivateKey(time.Now(), rsaPriv).Serialize(&buf); err != nil {
		t.Fatal(err)
	}

	p, err := Read(&buf)
	if err != nil {
		t.Fatal(err)
	}

	read := p.(*PrivateKey)

	if !read.PrivateKey.(*rsa.PrivateKey).Equal(rsaPriv) {
		t.Fatal("private keys not equal")
	}
}
```
This test fail with `private keys not equal` with the current `crypto` package, but succeed with my fix.

Here is the annotated de-serialization function to highlight the reading order:
```go
func (pk *PrivateKey) parseRSAPrivateKey(data []byte) (err error) {
	rsaPub := pk.PublicKey.PublicKey.(*rsa.PublicKey)
	rsaPriv := new(rsa.PrivateKey)
	rsaPriv.PublicKey = *rsaPub

	buf := bytes.NewBuffer(data)
	d, _, err := readMPI(buf) // priv.D
	if err != nil {
		return
	}
	p, _, err := readMPI(buf) // priv.Primes[1]
	if err != nil {
		return
	}
	q, _, err := readMPI(buf) // priv.Primes[0]
	if err != nil {
		return
	}

	rsaPriv.D = new(big.Int).SetBytes(d)
	rsaPriv.Primes = make([]*big.Int, 2)
	rsaPriv.Primes[0] = new(big.Int).SetBytes(p)
	rsaPriv.Primes[1] = new(big.Int).SetBytes(q)
	if err := rsaPriv.Validate(); err != nil {
		return err
	}
	rsaPriv.Precompute()
	pk.PrivateKey = rsaPriv
	pk.Encrypted = false
	pk.encryptedData = nil

	return nil
}
```
