### PR TITLE
bcrypt: simplify bcrypt's base64 by using base64.Nopadding

### DIFF
--- a/bcrypt/base64.go
+++ b/bcrypt/base64.go
@@ -8,28 +8,19 @@ import "encoding/base64"
 
 const alphabet = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
-var bcEncoding = base64.NewEncoding(alphabet)
+var bcEncoding = base64.NewEncoding(alphabet).WithPadding(base64.NoPadding)
 
 func base64Encode(src []byte) []byte {
-	n := bcEncoding.EncodedLen(len(src))
-	dst := make([]byte, n)
+	dst := make([]byte, bcEncoding.EncodedLen(len(src)))
 	bcEncoding.Encode(dst, src)
-	for dst[n-1] == '=' {
-		n--
-	}
-	return dst[:n]
+	return dst
 }
 
 func base64Decode(src []byte) ([]byte, error) {
-	numOfEquals := 4 - (len(src) % 4)
-	for i := 0; i < numOfEquals; i++ {
-		src = append(src, '=')
-	}
-
 	dst := make([]byte, bcEncoding.DecodedLen(len(src)))
-	n, err := bcEncoding.Decode(dst, src)
+	_, err := bcEncoding.Decode(dst, src)
 	if err != nil {
 		return nil, err
 	}
-	return dst[:n], nil
+	return dst, nil
 }


### PR DESCRIPTION
In the existing bcrypt, pad and unpad by the base64Encode and base64Decode methods of bcrypt/base64.
However, in the current encoding/base64 implementation, WithPadding(base64) can omit them.

Also, in the current implementation, if src is 0 bytes at Encode, `dst[n-1] == '='` will result in an out-of-range.
current base64Encode is not affected by this because it handle either fixed-length salt(16bytes) or hash values(23bytes).

This pull request simplifies the code and reduce the risk of future out-of-range.