### PR TITLE
acme/autocert: include email in example

### DIFF
--- a/acme/autocert/example_test.go
+++ b/acme/autocert/example_test.go
@@ -24,6 +24,7 @@ func ExampleManager() {
 	m := &autocert.Manager{
 		Cache:      autocert.DirCache("secret-dir"),
 		Prompt:     autocert.AcceptTOS,
+		Email:      "example@example.org",
 		HostPolicy: autocert.HostWhitelist("example.org", "www.example.org"),
 	}
 	s := &http.Server{


### PR DESCRIPTION
At Let's Encrypt, we've found that most autocert users do not provide an email address, which makes it hard to get in touch when things go wrong with their client. Demonstrating how to provide an email will probably encourage more people to provide one.