### PR TITLE
ssh: fix server to accept rsa-sha2-256 and rsa-sha2-512 signatures

### DIFF
--- a/ssh/client_auth_test.go
+++ b/ssh/client_auth_test.go
@@ -105,15 +105,17 @@ func tryAuthBothSides(t *testing.T, config *ClientConfig, gssAPIWithMICConfig *G
 }
 
 func TestClientAuthPublicKey(t *testing.T) {
-	config := &ClientConfig{
-		User: "testuser",
-		Auth: []AuthMethod{
-			PublicKeys(testSigners["rsa"]),
-		},
-		HostKeyCallback: InsecureIgnoreHostKey(),
-	}
-	if err := tryAuth(t, config); err != nil {
-		t.Fatalf("unable to dial remote side: %s", err)
+	for _, s := range []string{"rsa", "rsa-sha2-256", "rsa-sha2-512"} {
+		config := &ClientConfig{
+			User: "testuser",
+			Auth: []AuthMethod{
+				PublicKeys(testSigners[s]),
+			},
+			HostKeyCallback: InsecureIgnoreHostKey(),
+		}
+		if err := tryAuth(t, config); err != nil {
+			t.Fatalf("unable to dial remote side: %s", err)
+		}
 	}
 }
 

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -284,7 +284,7 @@ func (s *connection) serverHandshake(config *ServerConfig) (*Permissions, error)
 
 func isAcceptableAlgo(algo string) bool {
 	switch algo {
-	case KeyAlgoRSA, KeyAlgoDSA, KeyAlgoECDSA256, KeyAlgoECDSA384, KeyAlgoECDSA521, KeyAlgoSKECDSA256, KeyAlgoED25519, KeyAlgoSKED25519,
+	case KeyAlgoRSA, SigAlgoRSASHA2256, SigAlgoRSASHA2512, KeyAlgoDSA, KeyAlgoECDSA256, KeyAlgoECDSA384, KeyAlgoECDSA521, KeyAlgoSKECDSA256, KeyAlgoED25519, KeyAlgoSKED25519,
 		CertAlgoRSAv01, CertAlgoDSAv01, CertAlgoECDSA256v01, CertAlgoECDSA384v01, CertAlgoECDSA521v01, CertAlgoSKECDSA256v01, CertAlgoED25519v01, CertAlgoSKED25519v01:
 		return true
 	}

--- a/ssh/testdata_test.go
+++ b/ssh/testdata_test.go
@@ -10,9 +10,7 @@ package ssh
 
 import (
 	"crypto/rand"
-	"errors"
 	"fmt"
-	"io"
 
 	"golang.org/x/crypto/ssh/testdata"
 )
@@ -22,32 +20,6 @@ var (
 	testSigners     map[string]Signer
 	testPublicKeys  map[string]PublicKey
 )
-
-type testAlgoSigner struct {
-	signer Signer
-	algo   string
-}
-
-func (tas *testAlgoSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*Signature, error) {
-	if as, ok := tas.signer.(AlgorithmSigner); ok {
-		if algorithm == "" {
-			algorithm = tas.algo
-		}
-		return as.SignWithAlgorithm(rand, data, algorithm)
-	}
-	return nil, errors.New("not an AlgorithmSigner")
-}
-
-func (tas *testAlgoSigner) Sign(rand io.Reader, data []byte) (*Signature, error) {
-	if as, ok := tas.signer.(AlgorithmSigner); ok {
-		return as.SignWithAlgorithm(rand, data, tas.algo)
-	}
-	return nil, errors.New("not an AlgorithmSigner")
-}
-
-func (tas *testAlgoSigner) PublicKey() PublicKey {
-	return tas.signer.PublicKey()
-}
 
 func init() {
 	var err error
@@ -65,13 +37,6 @@ func init() {
 		if err != nil {
 			panic(fmt.Sprintf("Unable to create signer for test key %s: %v", t, err))
 		}
-		testPublicKeys[t] = testSigners[t].PublicKey()
-	}
-
-	// Create rsa-sha2-256 and rsa-sha2-512 signers
-	for _, t := range []string{"rsa-sha2-256", "rsa-sha2-512"} {
-		testPrivateKeys[t] = testPrivateKeys["rsa"]
-		testSigners[t] = &testAlgoSigner{signer: testSigners["rsa"], algo: t}
 		testPublicKeys[t] = testSigners[t].PublicKey()
 	}
 


### PR DESCRIPTION
This pull request fixes serverAuthenticate() to accept "rsa-sha2-256" and "rsa-sha2-512" public key algorithm names and signature format in user auth messages. Additionally this pr adds unit tests for RSA publickey authentication using rsa-sha2-256 and rsa-sha2-512 signatures.

Fixes https://github.com/golang/go/issues/46569