### PR TITLE
ssh: fix publickey ack missing parcital success

### DIFF
--- a/ssh/client_auth.go
+++ b/ssh/client_auth.go
@@ -307,6 +307,13 @@ func confirmKeyAck(key PublicKey, c packetConn) (bool, error) {
 			}
 			return true, nil
 		case msgUserAuthFailure:
+			var msg userAuthFailureMsg
+			if err := Unmarshal(packet, &msg); err != nil {
+				return false, err
+			}
+			if msg.PartialSuccess {
+				return true, nil
+			}
 			return false, nil
 		default:
 			return false, unexpectedMessageError(msgUserAuthSuccess, packet[0])


### PR DESCRIPTION
Accoding to RFC 4252 section 5.1, the server rejects the authentication request with 'partial success' will contain the name-list of method name that can continue to auth.

The client should continue auth with 'method name'.