### PR TITLE
blake2b: export Digest and (*Digest).Init

### DIFF
--- a/blake2b/blake2b.go
+++ b/blake2b/blake2b.go
@@ -99,19 +99,9 @@ func New256(key []byte) (hash.Hash, error) { return newDigest(Size256, key) }
 func New(size int, key []byte) (hash.Hash, error) { return newDigest(size, key) }
 
 func newDigest(hashSize int, key []byte) (*Digest, error) {
-	if hashSize < 1 || hashSize > Size {
-		return nil, errHashSize
-	}
-	if len(key) > Size {
-		return nil, errKeySize
-	}
-	d := &Digest{
-		size:   hashSize,
-		keyLen: len(key),
-	}
-	copy(d.key[:], key)
-	d.Reset()
-	return d, nil
+	d := new(Digest)
+	err := d.Init(hashSize, key)
+	return d, err
 }
 
 func checkSum(sum *[Size]byte, hashSize int, data []byte) {
@@ -198,6 +188,22 @@ func (d *Digest) UnmarshalBinary(b []byte) error {
 	copy(d.block[:], b[:BlockSize])
 	b = b[BlockSize:]
 	d.offset = int(b[0])
+	return nil
+}
+
+// Init initializes d with the specified parameters. For a description of the
+// parameters and possible errors, see New.
+func (d *Digest) Init(size int, key []byte) error {
+	if size < 1 || size > Size {
+		return errHashSize
+	}
+	if len(key) > Size {
+		return errKeySize
+	}
+	d.size = size
+	d.keyLen = len(key)
+	copy(d.key[:], key)
+	d.Reset()
 	return nil
 }
 

--- a/blake2b/blake2b.go
+++ b/blake2b/blake2b.go
@@ -98,14 +98,14 @@ func New256(key []byte) (hash.Hash, error) { return newDigest(Size256, key) }
 // and BinaryUnmarshaler for state (de)serialization as documented by hash.Hash.
 func New(size int, key []byte) (hash.Hash, error) { return newDigest(size, key) }
 
-func newDigest(hashSize int, key []byte) (*digest, error) {
+func newDigest(hashSize int, key []byte) (*Digest, error) {
 	if hashSize < 1 || hashSize > Size {
 		return nil, errHashSize
 	}
 	if len(key) > Size {
 		return nil, errKeySize
 	}
-	d := &digest{
+	d := &Digest{
 		size:   hashSize,
 		keyLen: len(key),
 	}
@@ -143,7 +143,8 @@ func checkSum(sum *[Size]byte, hashSize int, data []byte) {
 	}
 }
 
-type digest struct {
+// Digest implements the BLAKE2b hash algorithm.
+type Digest struct {
 	h      [8]uint64
 	c      [2]uint64
 	size   int
@@ -159,7 +160,8 @@ const (
 	marshaledSize = len(magic) + 8*8 + 2*8 + 1 + BlockSize + 1
 )
 
-func (d *digest) MarshalBinary() ([]byte, error) {
+// MarshalBinary implements binary.Marshaler.
+func (d *Digest) MarshalBinary() ([]byte, error) {
 	if d.keyLen != 0 {
 		return nil, errors.New("crypto/blake2b: cannot marshal MACs")
 	}
@@ -177,7 +179,8 @@ func (d *digest) MarshalBinary() ([]byte, error) {
 	return b, nil
 }
 
-func (d *digest) UnmarshalBinary(b []byte) error {
+// UnmarshalBinary implements binary.Unmarshaler.
+func (d *Digest) UnmarshalBinary(b []byte) error {
 	if len(b) < len(magic) || string(b[:len(magic)]) != magic {
 		return errors.New("crypto/blake2b: invalid hash state identifier")
 	}
@@ -198,11 +201,14 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-func (d *digest) BlockSize() int { return BlockSize }
+// BlockSize implements hash.Hash.
+func (d *Digest) BlockSize() int { return BlockSize }
 
-func (d *digest) Size() int { return d.size }
+// Size implements hash.Hash.
+func (d *Digest) Size() int { return d.size }
 
-func (d *digest) Reset() {
+// Reset implements hash.Hash.
+func (d *Digest) Reset() {
 	d.h = iv
 	d.h[0] ^= uint64(d.size) | (uint64(d.keyLen) << 8) | (1 << 16) | (1 << 24)
 	d.offset, d.c[0], d.c[1] = 0, 0, 0
@@ -212,7 +218,8 @@ func (d *digest) Reset() {
 	}
 }
 
-func (d *digest) Write(p []byte) (n int, err error) {
+// Write implements hash.Hash.
+func (d *Digest) Write(p []byte) (n int, err error) {
 	n = len(p)
 
 	if d.offset > 0 {
@@ -243,13 +250,14 @@ func (d *digest) Write(p []byte) (n int, err error) {
 	return
 }
 
-func (d *digest) Sum(sum []byte) []byte {
+// Sum implements hash.Hash.
+func (d *Digest) Sum(sum []byte) []byte {
 	var hash [Size]byte
 	d.finalize(&hash)
 	return append(sum, hash[:d.size]...)
 }
 
-func (d *digest) finalize(hash *[Size]byte) {
+func (d *Digest) finalize(hash *[Size]byte) {
 	var block [BlockSize]byte
 	copy(block[:], d.block[:d.offset])
 	remaining := uint64(BlockSize - d.offset)

--- a/blake2b/blake2x.go
+++ b/blake2b/blake2x.go
@@ -60,7 +60,7 @@ func NewXOF(size uint32, key []byte) (XOF, error) {
 		size = magicUnknownOutputLength
 	}
 	x := &xof{
-		d: digest{
+		d: Digest{
 			size:   Size,
 			keyLen: len(key),
 		},
@@ -72,7 +72,7 @@ func NewXOF(size uint32, key []byte) (XOF, error) {
 }
 
 type xof struct {
-	d                digest
+	d                Digest
 	length           uint32
 	remaining        uint64
 	cfg, root, block [Size]byte
@@ -169,7 +169,7 @@ func (x *xof) Read(p []byte) (n int, err error) {
 	return
 }
 
-func (d *digest) initConfig(cfg *[Size]byte) {
+func (d *Digest) initConfig(cfg *[Size]byte) {
 	d.offset, d.c[0], d.c[1] = 0, 0, 0
 	for i := range d.h {
 		d.h[i] = iv[i] ^ binary.LittleEndian.Uint64(cfg[i*8:])


### PR DESCRIPTION
This allows clients to eliminate allocations when streaming data into the hash.

Thanks to https://github.com/golang/go/issues/33160, allocations are already eliminated in many simple contexts. However, once you want to do anything more sophisticated -- specifically, introducing helper functions or types -- it becomes difficult or impossible to avoid allocations due to `hash.Hash`. As a motivating example:

```go
// 1. This doesn't allocate, but also isn't very useful.
func hashUint64(u uint64) (sum [32]byte) {
    buf := make([]byte, 8)
    binary.LittleEndian.PutUint64(buf, u)
    h, _ := blake2b.New256(nil) // will be devirtualized to *blake2b.digest
    h.Write(buf)
    h.Sum(sum[:0])
    return
}

// 2. This allocates once per call.
func writeUint64(h hash.Hash, u uint64) {
    buf := make([]byte, 8)
    binary.LittleEndian.PutUint64(buf, u)
    h.Write(buf) // buf escapes here
}

// 3. This allocates twice per Uint64Hasher.
type Uint64Hasher struct {
    h   hash.Hash
    buf [8]byte
}
func (h *Uint64Hasher) WriteUint64(u uint64) {
    binary.LittleEndian.PutUint64(h.buf[:], u)
    h.h.Write(h.buf[:]) // h.buf escapes here
}
func NewUint64Hasher() *Uint64Hasher {
    h, _ := blake2b.New256(nil)
    return &Uint64Hasher{
        h: h, // h escapes here
    }
}
```

It is clear that substituting a concrete type for the `hash.Hash` in 2 and 3 will eliminate all allocations, but this is not currently possible. This PR exports  `blake2b.Digest`, which allows clients to access the concrete type without breaking API compatibility.

Originally, I had hoped that merely exporting the type would be sufficient. Clients could then use a type assertion on the returned `hash.Hash` to convert it to a `*blake2b.Digest`. Unfortunately, this isn't good enough for `NewUint64Hasher`, because the combination of constructors invariably exceeds the inlining budget, causing the Digest to escape:
```go
// cannot inline NewUint64Hasher: function too complex: cost 87 exceeds budget 80
func NewUint64Hasher() *Uint64Hasher {
    h, _ := blake2b.New256(nil)
    return &Uint64Hasher{
        h: h.(*blake2b.Digest),
    }
}
```
Now, it *is* possible to refactor `blake2b.New256` such that the combined budget is not exceeded, by manually inlining `newDigest` and removing a few unnecessary expressions:
```go
// can inline New256 with cost 61
func New256(key []byte) (hash.Hash, error) {
    if len(key) > Size {
        return nil, errKeySize
    }
    d := &Digest{
        size:   Size256,
        keyLen: len(key),
        h:      iv,
    }
    copy(d.key[:], key)
    d.h[0] ^= uint64(Size256) | (uint64(len(key)) << 8) | (1 << 16) | (1 << 24)
    if len(key) > 0 {
        d.block = d.key
        d.offset = BlockSize
    }
    return d, nil
}
// can inline NewUint64Hasher with cost 75
```
...but this is probably too ugly to be worth it, considering we'd have to do this for every constructor.

Another option would be to add a `NewDigest(size int, key []byte) (*Digest, error)` method. Unfortunately, this too exceeds the inlining budget, due to the `errHashSize` check.

So the only practical recourse is to add an `Init` method. We can then write the constructor as:
```go
// can inline NewUint64Hasher with cost 74 
func NewUint64Hasher() *Uint64Hasher {
    h := new(blake2b.Digest)
    h.Init(blake2b.Size256, nil) // safe to ignore error
    return &Uint64Hasher{
        h: h,
    }
}
```
Since the `Digest` is declared in `NewUint64Hasher`, it won't escape to the heap as long as `NewUint64Hasher` itself can be inlined. Benchmarking confirms that this is zero-alloc:
```go
func BenchmarkHasherAlloc(b *testing.B) {
    for i := 0; i < n; i++ {
        h := NewUint64Hasher()
        h.WriteUint64(uint64(i))
    }
}
```

Assuming this is accepted, I'm happy to open equivalent PRs for other hash functions as well.