### PR TITLE
x/crypto/ssh: add missing subsystem handling

### DIFF
--- a/ssh/session.go
+++ b/ssh/session.go
@@ -221,6 +221,9 @@ type subsystemRequestMsg struct {
 // RequestSubsystem requests the association of a subsystem with the session on the remote host.
 // A subsystem is a predefined command that runs in the background when the ssh session is initiated
 func (s *Session) RequestSubsystem(subsystem string) error {
+	if s.started {
+		return errors.New("ssh: session already started")
+	}
 	msg := subsystemRequestMsg{
 		Subsystem: subsystem,
 	}
@@ -228,7 +231,10 @@ func (s *Session) RequestSubsystem(subsystem string) error {
 	if err == nil && !ok {
 		err = errors.New("ssh: subsystem request failed")
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	return s.start()
 }
 
 // RFC 4254 Section 6.7.


### PR DESCRIPTION
Subsystem requests are aliases that are similar to exec or
shell requests. The server can respond to subsystem requests
with exit status or exit signal.  This means in session handling
code, subsystem requests also need be started and waited.

Also see RFC4254:
https://datatracker.ietf.org/doc/html/rfc4254#section-6.5