### PR TITLE
ssh/agent: sign data without a locked mutex

### DIFF
--- a/ssh/agent/keyring.go
+++ b/ssh/agent/keyring.go
@@ -193,7 +193,7 @@ func (r *keyring) SignWithFlags(key ssh.PublicKey, data []byte, flags SignatureF
 	}
 
 	r.expireKeysLocked()
-	keys := r.keys
+	keys := append(r.keys[:0:0], r.keys...)
 	r.mu.Unlock()
 
 	wanted := key.Marshal()


### PR DESCRIPTION
Currently signing requests are executed while the keyring mutex is
locked. However it is not necessary to do so. By unlocking as early
as possible we can take advantage of goroutines and serve different
signing requests in parallel.