### PR TITLE
x/crypto/bcrypt: use base64.NoPadding

### DIFF
--- a/bcrypt/base64.go
+++ b/bcrypt/base64.go
@@ -8,24 +8,15 @@ import "encoding/base64"
 
 const alphabet = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
-var bcEncoding = base64.NewEncoding(alphabet)
+var bcEncoding = base64.NewEncoding(alphabet).WithPadding(base64.NoPadding)
 
 func base64Encode(src []byte) []byte {
-	n := bcEncoding.EncodedLen(len(src))
-	dst := make([]byte, n)
+	dst := make([]byte, bcEncoding.EncodedLen(len(src)))
 	bcEncoding.Encode(dst, src)
-	for dst[n-1] == '=' {
-		n--
-	}
-	return dst[:n]
+	return dst
 }
 
 func base64Decode(src []byte) ([]byte, error) {
-	numOfEquals := 4 - (len(src) % 4)
-	for i := 0; i < numOfEquals; i++ {
-		src = append(src, '=')
-	}
-
 	dst := make([]byte, bcEncoding.DecodedLen(len(src)))
 	n, err := bcEncoding.Decode(dst, src)
 	if err != nil {


### PR DESCRIPTION
Fixes golang/go#35810