### PR TITLE
ssh: add support for extension negotiation (rfc 8308)

### DIFF
--- a/ssh/common_test.go
+++ b/ssh/common_test.go
@@ -111,6 +111,28 @@ func TestFindAgreedAlgorithms(t *testing.T) {
 		},
 
 		testcase{
+			name: "server ext info kex chosen",
+			serverIn: kexInitMsg{
+				KexAlgos: []string{extInfoServer},
+			},
+			clientIn: kexInitMsg{
+				KexAlgos: []string{extInfoServer},
+			},
+			wantErr: true,
+		},
+
+		testcase{
+			name: "client ext info kex chosen",
+			serverIn: kexInitMsg{
+				KexAlgos: []string{extInfoClient},
+			},
+			clientIn: kexInitMsg{
+				KexAlgos: []string{extInfoClient},
+			},
+			wantErr: true,
+		},
+
+		testcase{
 			name: "client decides cipher",
 			serverIn: kexInitMsg{
 				CiphersClientServer: []string{"cipher1", "cipher2"},

--- a/ssh/handshake.go
+++ b/ssh/handshake.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
 	"sync"
 )
 
@@ -94,6 +95,16 @@ type handshakeTransport struct {
 
 	// The session ID or nil if first kex did not complete yet.
 	sessionID []byte
+
+	// True if the other side has signaled support for extensions.
+	extInfoSupported bool
+	// True if the first ext info message has been sent immediately following
+	// SSH_MSG_NEWKEYS, false otherwise.
+	extInfoSent bool
+
+	// extensions is a map of extensions received from the other side as
+	// part of extension negotiation.
+	extensions map[string][]byte
 }
 
 type pendingKex struct {
@@ -109,6 +120,7 @@ func newHandshakeTransport(conn keyingTransport, config *Config, clientVersion, 
 		incoming:      make(chan []byte, chanSize),
 		requestKex:    make(chan struct{}, 1),
 		startKex:      make(chan *pendingKex, 1),
+		extensions:    map[string][]byte{},
 
 		config: config,
 	}
@@ -460,8 +472,14 @@ func (t *handshakeTransport) sendKexInit() error {
 			msg.ServerHostKeyAlgos = append(
 				msg.ServerHostKeyAlgos, k.PublicKey().Type())
 		}
+		if hasString(ExtServerSigAlgs, t.config.Extensions) {
+			msg.KexAlgos = append(msg.KexAlgos, extInfoServer)
+		}
 	} else {
 		msg.ServerHostKeyAlgos = t.hostKeyAlgorithms
+		if hasString(ExtServerSigAlgs, t.config.Extensions) {
+			msg.KexAlgos = append(msg.KexAlgos, extInfoClient)
+		}
 	}
 	packet := Marshal(msg)
 
@@ -606,6 +624,36 @@ func (t *handshakeTransport) enterKeyExchange(otherInitPacket []byte) error {
 		return err
 	} else if packet[0] != msgNewKeys {
 		return unexpectedMessageError(msgNewKeys, packet[0])
+	}
+
+	// Handle the ext-info-X extension signal from RFC8308 section 2.
+	// First, see if the other side supports us sending SSH_MSG_EXT_INFO to them.
+	if isClient {
+		// We're on the client side, see if the server sent the extension signal
+		t.extInfoSupported = hasString(extInfoServer, serverInit.KexAlgos)
+	} else {
+		// We're on the server side, see if the client sent the extension signal
+		t.extInfoSupported = hasString(extInfoClient, clientInit.KexAlgos)
+	}
+	if t.extInfoSupported && !t.extInfoSent && len(t.config.Extensions) > 0 {
+		// The other side supports ext info, an ext info message hasn't been sent this session,
+		// and we have at least one extension enabled, so send an SSH_MSG_EXT_INFO message.
+		extensions := map[string][]byte{}
+		if !isClient {
+			if hasString(ExtServerSigAlgs, t.config.Extensions) {
+				// We're the server, the client supports SSH_MSG_EXT_INFO and server-sig-algs
+				// is enabled. Prepare the server-sig-algos extension message to send.
+				extensions[ExtServerSigAlgs] = []byte(strings.Join(supportedSigAlgs(), ","))
+			}
+		}
+		extInfo := extInfoMsg{
+			NumExtensions: uint32(len(extensions)),
+			Extensions:    extensions,
+		}
+		if err := t.conn.writePacket(Marshal(&extInfo)); err != nil {
+			return err
+		}
+		t.extInfoSent = true
 	}
 
 	return nil

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -255,18 +255,35 @@ func (s *connection) serverHandshake(config *ServerConfig) (*Permissions, error)
 	// We just did the key change, so the session ID is established.
 	s.sessionID = s.transport.getSessionID()
 
-	var packet []byte
-	if packet, err = s.transport.readPacket(); err != nil {
-		return nil, err
+	var serviceRequest serviceRequestMsg
+readServiceRequestLoop:
+	for {
+		var packet []byte
+		if packet, err = s.transport.readPacket(); err != nil {
+			return nil, err
+		}
+
+		switch packet[0] {
+		case msgExtInfo:
+			var extInfo extInfoMsg
+			if err := Unmarshal(packet, &extInfo); err != nil {
+				return nil, err
+			}
+			s.transport.extensions = extInfo.Extensions
+			continue
+		case msgServiceRequest:
+			if err = Unmarshal(packet, &serviceRequest); err != nil {
+				return nil, err
+			}
+			if serviceRequest.Service != serviceUserAuth {
+				return nil, errors.New("ssh: requested service '" + serviceRequest.Service + "' before authenticating")
+			}
+			break readServiceRequestLoop
+		default:
+			return nil, fmt.Errorf("ssh: unexpected message received")
+		}
 	}
 
-	var serviceRequest serviceRequestMsg
-	if err = Unmarshal(packet, &serviceRequest); err != nil {
-		return nil, err
-	}
-	if serviceRequest.Service != serviceUserAuth {
-		return nil, errors.New("ssh: requested service '" + serviceRequest.Service + "' before authenticating")
-	}
 	serviceAccept := serviceAcceptMsg{
 		Service: serviceUserAuth,
 	}
@@ -657,6 +674,14 @@ userAuthLoop:
 			return nil, err
 		}
 	}
+
+	// TODO(kxd) This is where the second ext info message was being sent as per
+	// RFC8308 section 2.4, but OpenSSH 8.8's client doesn't seem to like it. It
+	// thinks it's an unexpected packet for some reason. It seems like all the
+	// server implementations I've been able to find so far don't actually send
+	// this message, so it's probably fine to not have it. There aren't currently
+	// any extension values you'd want to hide from anonymous users at this point
+	// anyway, as far as I'm aware.
 
 	if err := s.transport.writePacket([]byte{msgUserAuthSuccess}); err != nil {
 		return nil, err


### PR DESCRIPTION
This adds support for SSH extension negotiation via SSH_MSG_EXT_INFO as defined in RFC 8308 [1]. It also adds support for the `server-sig-algs` extension on both the client and server sides.

[1] https://datatracker.ietf.org/doc/html/rfc8308

Fixes golang/go#49269