### PR TITLE
ssh: support RSA SHA-2 (RFC8332) signatures.

### DIFF
--- a/ssh/certs.go
+++ b/ssh/certs.go
@@ -18,6 +18,8 @@ import (
 // for certificate types supported by this package.
 const (
 	CertAlgoRSAv01        = "ssh-rsa-cert-v01@openssh.com"
+	CertAlgoRSASHA2256v01 = "rsa-sha2-256-cert-v01@openssh.com"
+	CertAlgoRSASHA2512v01 = "rsa-sha2-512-cert-v01@openssh.com"
 	CertAlgoDSAv01        = "ssh-dss-cert-v01@openssh.com"
 	CertAlgoECDSA256v01   = "ecdsa-sha2-nistp256-cert-v01@openssh.com"
 	CertAlgoECDSA384v01   = "ecdsa-sha2-nistp384-cert-v01@openssh.com"
@@ -423,6 +425,12 @@ func (c *Certificate) SignCert(rand io.Reader, authority Signer) error {
 	}
 	c.SignatureKey = authority.PublicKey()
 
+	if v, ok := authority.(AlgorithmSigner); ok {
+		if v.PublicKey().Type() == KeyAlgoRSA {
+			authority = &defaultAlgorithmSigner{v, SigAlgoRSASHA2512}
+		}
+	}
+
 	sig, err := authority.Sign(rand, c.bytesForSigning())
 	if err != nil {
 		return err
@@ -433,6 +441,8 @@ func (c *Certificate) SignCert(rand io.Reader, authority Signer) error {
 
 var certAlgoNames = map[string]string{
 	KeyAlgoRSA:        CertAlgoRSAv01,
+	KeyAlgoRSASHA2256: CertAlgoRSASHA2256v01,
+	KeyAlgoRSASHA2512: CertAlgoRSASHA2512v01,
 	KeyAlgoDSA:        CertAlgoDSAv01,
 	KeyAlgoECDSA256:   CertAlgoECDSA256v01,
 	KeyAlgoECDSA384:   CertAlgoECDSA384v01,

--- a/ssh/common.go
+++ b/ssh/common.go
@@ -69,10 +69,12 @@ var preferredKexAlgos = []string{
 // supportedHostKeyAlgos specifies the supported host-key algorithms (i.e. methods
 // of authenticating servers) in preference order.
 var supportedHostKeyAlgos = []string{
-	CertAlgoRSAv01, CertAlgoDSAv01, CertAlgoECDSA256v01,
+	CertAlgoRSASHA2512v01, CertAlgoRSASHA2256v01, CertAlgoRSAv01,
+	CertAlgoDSAv01, CertAlgoECDSA256v01,
 	CertAlgoECDSA384v01, CertAlgoECDSA521v01, CertAlgoED25519v01,
 
 	KeyAlgoECDSA256, KeyAlgoECDSA384, KeyAlgoECDSA521,
+	KeyAlgoRSASHA2512, KeyAlgoRSASHA2256,
 	KeyAlgoRSA, KeyAlgoDSA,
 
 	KeyAlgoED25519,
@@ -91,6 +93,8 @@ var supportedCompressions = []string{compressionNone}
 // hashes needed for signature verification.
 var hashFuncs = map[string]crypto.Hash{
 	KeyAlgoRSA:          crypto.SHA1,
+	KeyAlgoRSASHA2256:   crypto.SHA256,
+	KeyAlgoRSASHA2512:   crypto.SHA512,
 	KeyAlgoDSA:          crypto.SHA1,
 	KeyAlgoECDSA256:     crypto.SHA256,
 	KeyAlgoECDSA384:     crypto.SHA384,

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -34,6 +34,8 @@ import (
 // package.
 const (
 	KeyAlgoRSA        = "ssh-rsa"
+	KeyAlgoRSASHA2256 = "rsa-sha2-256"
+	KeyAlgoRSASHA2512 = "rsa-sha2-512"
 	KeyAlgoDSA        = "ssh-dss"
 	KeyAlgoECDSA256   = "ecdsa-sha2-nistp256"
 	KeyAlgoSKECDSA256 = "sk-ecdsa-sha2-nistp256@openssh.com"
@@ -57,7 +59,7 @@ const (
 // Use ParsePublicKey for keys with prepended algorithm.
 func parsePubKey(in []byte, algo string) (pubKey PublicKey, rest []byte, err error) {
 	switch algo {
-	case KeyAlgoRSA:
+	case KeyAlgoRSA, KeyAlgoRSASHA2256, KeyAlgoRSASHA2512:
 		return parseRSA(in)
 	case KeyAlgoDSA:
 		return parseDSA(in)
@@ -69,7 +71,7 @@ func parsePubKey(in []byte, algo string) (pubKey PublicKey, rest []byte, err err
 		return parseED25519(in)
 	case KeyAlgoSKED25519:
 		return parseSKEd25519(in)
-	case CertAlgoRSAv01, CertAlgoDSAv01, CertAlgoECDSA256v01, CertAlgoECDSA384v01, CertAlgoECDSA521v01, CertAlgoSKECDSA256v01, CertAlgoED25519v01, CertAlgoSKED25519v01:
+	case CertAlgoRSAv01, CertAlgoRSASHA2256v01, CertAlgoRSASHA2512v01, CertAlgoDSAv01, CertAlgoECDSA256v01, CertAlgoECDSA384v01, CertAlgoECDSA521v01, CertAlgoSKECDSA256v01, CertAlgoED25519v01, CertAlgoSKED25519v01:
 		cert, err := parseCert(in, certToPrivAlgo(algo))
 		if err != nil {
 			return nil, nil, err
@@ -929,6 +931,23 @@ func NewSignerFromKey(key interface{}) (Signer, error) {
 	default:
 		return nil, fmt.Errorf("ssh: unsupported key type %T", key)
 	}
+}
+
+type defaultAlgorithmSigner struct {
+	AlgorithmSigner
+	algorithm string
+}
+
+func (s *defaultAlgorithmSigner) PublicKey() PublicKey {
+	return s.AlgorithmSigner.PublicKey()
+}
+
+func (s *defaultAlgorithmSigner) Sign(rand io.Reader, data []byte) (*Signature, error) {
+	return s.AlgorithmSigner.SignWithAlgorithm(rand, data, s.algorithm)
+}
+
+func (s *defaultAlgorithmSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*Signature, error) {
+	return s.AlgorithmSigner.SignWithAlgorithm(rand, data, algorithm)
 }
 
 func newDSAPrivateKey(key *dsa.PrivateKey) (Signer, error) {


### PR DESCRIPTION
Go