### PR TITLE
DSA - FIPS 186-3 key sizes

### DIFF
--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -409,10 +409,8 @@ func (k *dsaPublicKey) Type() string {
 }
 
 func checkDSAParams(param *dsa.Parameters) error {
-	// SSH specifies FIPS 186-2, which only provided a single size
-	// (1024 bits) DSA key. FIPS 186-3 allows for larger key
-	// sizes, which would confuse SSH.
-	if l := param.P.BitLen(); l != 1024 {
+	// SSH specifies FIPS 186-3, which provides (1024, 2048, 3072) sizes.
+	if l := param.P.BitLen(); l != 1024 && l != 2048 && l != 3072 {
 		return fmt.Errorf("ssh: unsupported DSA key size %d", l)
 	}
 

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -409,7 +409,7 @@ func (k *dsaPublicKey) Type() string {
 }
 
 func checkDSAParams(param *dsa.Parameters) error {
-	// SSH specifies FIPS 186-3, which provides (1024, 2048, 3072) sizes.
+	// SSH and SFTP requires FIPS 186-3, which provides (1024, 2048, 3072) sizes.
 	if l := param.P.BitLen(); l != 1024 && l != 2048 && l != 3072 {
 		return fmt.Errorf("ssh: unsupported DSA key size %d", l)
 	}


### PR DESCRIPTION
As mentioned in this [issue](https://github.com/golang/go/issues/23751), DSA with 2048 key size is is required by many projects.
Especially for SFTP for my use case. Even google query for [typical dsa key size](https://www.google.com/search?q=typical+dsa+key+size) is 2048.
And [FIPS 186-3](https://csrc.nist.gov/csrc/media/publications/fips/186/3/archive/2009-06-25/documents/fips_186-3.pdf) supports (1024, 2048, 3072) keys.

