### PR TITLE
x/crypto/ssh: send ext-info-c only once

### DIFF
--- a/ssh/handshake.go
+++ b/ssh/handshake.go
@@ -479,10 +479,12 @@ func (t *handshakeTransport) sendKexInit() error {
 
 		// As a client we opt in to receiving SSH_MSG_EXT_INFO so we know what
 		// algorithms the server supports for public key authentication. See RFC
-		// 8303, Section 2.1.
-		msg.KexAlgos = make([]string, 0, len(t.config.KeyExchanges)+1)
-		msg.KexAlgos = append(msg.KexAlgos, t.config.KeyExchanges...)
-		msg.KexAlgos = append(msg.KexAlgos, "ext-info-c")
+		// 8308, Section 2.1.
+		if firstKeyExchange := t.sessionID == nil; firstKeyExchange {
+			msg.KexAlgos = make([]string, 0, len(t.config.KeyExchanges)+1)
+			msg.KexAlgos = append(msg.KexAlgos, t.config.KeyExchanges...)
+			msg.KexAlgos = append(msg.KexAlgos, "ext-info-c")
+		}
 	}
 
 	packet := Marshal(msg)


### PR DESCRIPTION
In accordance to RFC8308, send ext-info-c only during the first key
exchange. Some server implementations such as OpenSSH 7 will send an
extInfoMsg message each time when ext-info-c is received. This results
in a closed connection, as our client does not expect this message while
handling the mux.

See https://bugzilla.mindrot.org/show_bug.cgi?id=2929 regarding the
behaviour of OpenSSH if it sees ext-info-c in later key exchanges.

Fixes golang/go#51808