### PR TITLE
gopherjs: update chacha20 build tags to support gopherjs build

### DIFF
--- a/chacha20/chacha_noasm.go
+++ b/chacha20/chacha_noasm.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (!arm64 && !s390x && !ppc64le) || (arm64 && !go1.11) || !gc || purego
-// +build !arm64,!s390x,!ppc64le arm64,!go1.11 !gc purego
+//go:build (!arm64 && !s390x && !ppc64le) || (arm64 && !go1.11) || !gc || purego || js
+// +build !arm64,!s390x,!ppc64le arm64,!go1.11 !gc purego js
 
 package chacha20
 

--- a/chacha20/chacha_s390x.go
+++ b/chacha20/chacha_s390x.go
@@ -4,6 +4,7 @@
 
 //go:build gc && !purego
 // +build gc,!purego
+// +build !js
 
 package chacha20
 


### PR DESCRIPTION
With this PR merged, "gopherjs build -v ./..." works correctly for this entire repo.