### PR TITLE
ssh: add support for extension negotiation (rfc 8308)

### DIFF
--- a/ssh/client_auth.go
+++ b/ssh/client_auth.go
@@ -35,22 +35,9 @@ func (c *connection) clientAuthenticate(config *ClientConfig) error {
 	// RFC 8308, Section 2.4.
 	extensions := make(map[string][]byte)
 	if len(packet) > 0 && packet[0] == msgExtInfo {
-		var extInfo extInfoMsg
-		if err := Unmarshal(packet, &extInfo); err != nil {
+		extensions, err = parseExtInfoMsg(packet)
+		if err != nil {
 			return err
-		}
-		payload := extInfo.Payload
-		for i := uint32(0); i < extInfo.NumExtensions; i++ {
-			name, rest, ok := parseString(payload)
-			if !ok {
-				return parseError(msgExtInfo)
-			}
-			value, rest, ok := parseString(rest)
-			if !ok {
-				return parseError(msgExtInfo)
-			}
-			extensions[string(name)] = value
-			payload = rest
 		}
 		packet, err = c.transport.readPacket()
 		if err != nil {

--- a/ssh/client_auth_test.go
+++ b/ssh/client_auth_test.go
@@ -132,9 +132,7 @@ func TestClientAuthPublicKey(t *testing.T) {
 	if err := tryAuth(t, config); err != nil {
 		t.Fatalf("unable to dial remote side: %s", err)
 	}
-	// Once the server implements the server-sig-algs extension, this will turn
-	// into KeyAlgoRSASHA256.
-	if len(signer.used) != 1 || signer.used[0] != KeyAlgoRSA {
+	if len(signer.used) != 1 || signer.used[0] != KeyAlgoRSASHA256 {
 		t.Errorf("unexpected Sign/SignWithAlgorithm calls: %q", signer.used)
 	}
 }

--- a/ssh/common.go
+++ b/ssh/common.go
@@ -97,13 +97,13 @@ var supportedMACs = []string{
 
 var supportedCompressions = []string{compressionNone}
 
-// supportedServerSigAlgs defines the algorithms supported for pubkey authentication
-// in no particular order. See RFC 8308, Section 3.1.
-var supportedServerSigAlgs = []string{KeyAlgoRSASHA256,
-	KeyAlgoRSASHA512, KeyAlgoRSA,
-	KeyAlgoECDSA256, KeyAlgoECDSA384, KeyAlgoECDSA521,
-	KeyAlgoSKECDSA256, KeyAlgoED25519, KeyAlgoSKED25519,
-	KeyAlgoDSA,
+// supportedServerSigAlgs defines the algorithms supported for pubkey authentication.
+// Order should not matter, but to avoid any issues we use the same order as OpenSSH.
+// See RFC 8308, Section 3.1.
+var supportedServerSigAlgs = []string{KeyAlgoED25519, KeyAlgoSKED25519,
+	KeyAlgoRSA, KeyAlgoRSASHA256, KeyAlgoRSASHA512,
+	KeyAlgoDSA, KeyAlgoECDSA256, KeyAlgoECDSA384, KeyAlgoECDSA521,
+	KeyAlgoSKECDSA256,
 }
 
 // hashFuncs keeps the mapping of supported signature algorithms to their

--- a/ssh/common.go
+++ b/ssh/common.go
@@ -28,13 +28,8 @@ const (
 const (
 	extInfoServer    = "ext-info-s"
 	extInfoClient    = "ext-info-c"
-	ExtServerSigAlgs = "server-sig-algs"
+	extServerSigAlgs = "server-sig-algs"
 )
-
-// defaultExtensions lists extensions enabled by default.
-var defaultExtensions = []string{
-	ExtServerSigAlgs,
-}
 
 // supportedCiphers lists ciphers we support but might not recommend.
 var supportedCiphers = []string{
@@ -282,10 +277,6 @@ type Config struct {
 	// The allowed MAC algorithms. If unspecified then a sensible default
 	// is used.
 	MACs []string
-
-	// A list of enabled extensions. If unspecified then a sensible
-	// default is used
-	Extensions []string
 }
 
 // SetDefaults sets sensible values for unset fields in config. This is
@@ -313,10 +304,6 @@ func (c *Config) SetDefaults() {
 
 	if c.MACs == nil {
 		c.MACs = supportedMACs
-	}
-
-	if c.Extensions == nil {
-		c.Extensions = defaultExtensions
 	}
 
 	if c.RekeyThreshold == 0 {

--- a/ssh/common.go
+++ b/ssh/common.go
@@ -24,7 +24,8 @@ const (
 	serviceSSH      = "ssh-connection"
 )
 
-// These are string constants related to extensions and extension negotiation
+// These are string constants related to extensions and extension negotiation.
+// See RFC 8308
 const (
 	extInfoServer    = "ext-info-s"
 	extInfoClient    = "ext-info-c"
@@ -97,7 +98,7 @@ var supportedMACs = []string{
 var supportedCompressions = []string{compressionNone}
 
 // supportedServerSigAlgs defines the algorithms supported for pubkey authentication
-// in no particular order.
+// in no particular order. See RFC 8308, Section 3.1.
 var supportedServerSigAlgs = []string{KeyAlgoRSASHA256,
 	KeyAlgoRSASHA512, KeyAlgoRSA,
 	KeyAlgoECDSA256, KeyAlgoECDSA384, KeyAlgoECDSA521,

--- a/ssh/handshake.go
+++ b/ssh/handshake.go
@@ -457,6 +457,7 @@ func (t *handshakeTransport) sendKexInit() error {
 	io.ReadFull(rand.Reader, msg.Cookie[:])
 
 	isServer := len(t.hostKeys) > 0
+	firstKeyExchange := t.sessionID == nil
 	if isServer {
 		for _, k := range t.hostKeys {
 			// If k is an AlgorithmSigner, presume it supports all signature algorithms
@@ -475,7 +476,7 @@ func (t *handshakeTransport) sendKexInit() error {
 				msg.ServerHostKeyAlgos = append(msg.ServerHostKeyAlgos, keyFormat)
 			}
 		}
-		if firstKeyExchange := t.sessionID == nil; firstKeyExchange {
+		if firstKeyExchange {
 			msg.KexAlgos = make([]string, 0, len(t.config.KeyExchanges)+1)
 			msg.KexAlgos = append(msg.KexAlgos, t.config.KeyExchanges...)
 			msg.KexAlgos = append(msg.KexAlgos, extInfoServer)
@@ -486,7 +487,7 @@ func (t *handshakeTransport) sendKexInit() error {
 		// As a client we opt in to receiving SSH_MSG_EXT_INFO so we know what
 		// algorithms the server supports for public key authentication. See RFC
 		// 8308, Section 2.1.
-		if firstKeyExchange := t.sessionID == nil; firstKeyExchange {
+		if firstKeyExchange {
 			msg.KexAlgos = make([]string, 0, len(t.config.KeyExchanges)+1)
 			msg.KexAlgos = append(msg.KexAlgos, t.config.KeyExchanges...)
 			msg.KexAlgos = append(msg.KexAlgos, extInfoClient)

--- a/ssh/handshake.go
+++ b/ssh/handshake.go
@@ -479,9 +479,7 @@ func (t *handshakeTransport) sendKexInit() error {
 				msg.ServerHostKeyAlgos = append(msg.ServerHostKeyAlgos, keyFormat)
 			}
 		}
-		if contains(t.config.Extensions, ExtServerSigAlgs) {
-			msg.KexAlgos = append(msg.KexAlgos, extInfoServer)
-		}
+		msg.KexAlgos = append(msg.KexAlgos, extInfoServer)
 	} else {
 		msg.ServerHostKeyAlgos = t.hostKeyAlgorithms
 
@@ -642,13 +640,13 @@ func (t *handshakeTransport) enterKeyExchange(otherInitPacket []byte) error {
 
 	if !isClient {
 		// We're on the server side, see if the client sent the extension signal
-		if !t.extInfoSent && contains(clientInit.KexAlgos, extInfoClient) && contains(t.config.Extensions, ExtServerSigAlgs) {
+		if !t.extInfoSent && contains(clientInit.KexAlgos, extInfoClient) {
 			// The other side supports ext info, an ext info message hasn't been sent this session,
 			// and we have at least one extension enabled, so send an SSH_MSG_EXT_INFO message.
 			extensions := map[string][]byte{}
 			// We're the server, the client supports SSH_MSG_EXT_INFO and server-sig-algs
 			// is enabled. Prepare the server-sig-algos extension message to send.
-			extensions[ExtServerSigAlgs] = []byte(strings.Join(supportedServerSigAlgs, ","))
+			extensions[extServerSigAlgs] = []byte(strings.Join(supportedServerSigAlgs, ","))
 			var payload []byte
 			for k, v := range extensions {
 				payload = appendInt(payload, len(k))

--- a/ssh/handshake.go
+++ b/ssh/handshake.go
@@ -479,7 +479,11 @@ func (t *handshakeTransport) sendKexInit() error {
 				msg.ServerHostKeyAlgos = append(msg.ServerHostKeyAlgos, keyFormat)
 			}
 		}
-		msg.KexAlgos = append(msg.KexAlgos, extInfoServer)
+		if firstKeyExchange := t.sessionID == nil; firstKeyExchange {
+			msg.KexAlgos = make([]string, 0, len(t.config.KeyExchanges)+1)
+			msg.KexAlgos = append(msg.KexAlgos, t.config.KeyExchanges...)
+			msg.KexAlgos = append(msg.KexAlgos, extInfoServer)
+		}
 	} else {
 		msg.ServerHostKeyAlgos = t.hostKeyAlgorithms
 

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -256,13 +256,13 @@ func (s *connection) serverHandshake(config *ServerConfig) (*Permissions, error)
 	// We just did the key change, so the session ID is established.
 	s.sessionID = s.transport.getSessionID()
 
-	// the client could send a SSH_MSG_EXT_INFO before SSH_MSG_SERVICE_REQUEST
+	// the client could send a SSH_MSG_EXT_INFO after the first SSH_MSG_NEWKEYS
+	// and so before SSH_MSG_SERVICE_REQUEST. See RFC 8308, Section 2.4.
 	var packet []byte
 	if packet, err = s.transport.readPacket(); err != nil {
 		return nil, err
 	}
 
-	// be permissive and don't add contains(s.transport.config.Extensions, ExtServerSigAlgs)
 	if len(packet) > 0 && packet[0] == msgExtInfo {
 		// read SSH_MSG_EXT_INFO
 		var extInfo extInfoMsg

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -285,7 +285,6 @@ func (s *connection) serverHandshake(config *ServerConfig) (*Permissions, error)
 		}
 
 		// read the next packet
-		packet = nil
 		if packet, err = s.transport.readPacket(); err != nil {
 			return nil, err
 		}

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -265,25 +265,9 @@ func (s *connection) serverHandshake(config *ServerConfig) (*Permissions, error)
 
 	if len(packet) > 0 && packet[0] == msgExtInfo {
 		// read SSH_MSG_EXT_INFO
-		var extInfo extInfoMsg
-		extensions := make(map[string][]byte)
-		if err := Unmarshal(packet, &extInfo); err != nil {
+		if _, err := parseExtInfoMsg(packet); err != nil {
 			return nil, err
 		}
-		payload := extInfo.Payload
-		for i := uint32(0); i < extInfo.NumExtensions; i++ {
-			name, rest, ok := parseString(payload)
-			if !ok {
-				return nil, parseError(msgExtInfo)
-			}
-			value, rest, ok := parseString(rest)
-			if !ok {
-				return nil, parseError(msgExtInfo)
-			}
-			extensions[string(name)] = value
-			payload = rest
-		}
-
 		// read the next packet
 		if packet, err = s.transport.readPacket(); err != nil {
 			return nil, err


### PR DESCRIPTION
This is a rebase of the following PR

https://github.com/golang/crypto/pull/197

with some changes and improvements:

- added support for client certificate authentication
- removed read loop from server handshake
- adapted extInfoMsg to upstream changes

Signed-off-by: Nicola Murino <nicola.murino@gmail.com>