### PR TITLE
acme: add AccountKeyRollover

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -306,6 +306,20 @@ func (c *Client) UpdateReg(ctx context.Context, acct *Account) (*Account, error)
 	return c.updateRegRFC(ctx, acct)
 }
 
+// AccountKeyRollover attempts to transition a client's account key to a new key.
+// On success client's Key is updated which is not concurrency safe.
+// On failure an error will be returned.
+// If the error is already registered with the ACME provider the following is true:
+//  - error is of type acme.Error
+//  - StatusCode should be 409 (Conflict)
+//  - Location header will have the KID of the associated account
+//
+// More about account key rollover can be found at
+// https://tools.ietf.org/html/rfc8555#section-7.3.5.
+func (c *Client) AccountKeyRollover(ctx context.Context, newKey crypto.Signer) error {
+	return c.accountKeyRollover(ctx, newKey)
+}
+
 // Authorize performs the initial step in the pre-authorization flow,
 // as opposed to order-based flow.
 // The caller will then need to choose from and perform a set of returned

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -33,6 +33,10 @@ const noKeyID = KeyID("")
 // See https://tools.ietf.org/html/rfc8555#section-6.3 for more details.
 const noPayload = ""
 
+// noNonce indicates that the nonce should be omitted from the protected header.
+// See jwsEncodeJSON for details.
+const noNonce = ""
+
 // jsonWebSignature can be easily serialized into a JWS following
 // https://tools.ietf.org/html/rfc7515#section-3.2.
 type jsonWebSignature struct {
@@ -45,9 +49,14 @@ type jsonWebSignature struct {
 // The result is serialized in JSON format containing either kid or jwk
 // fields based on the provided KeyID value.
 //
+// The claimset is marshalled using json.Marshal unless it is a string.
+// In which case it is inserted directly into the message.
+//
 // If kid is non-empty, its quoted value is inserted in the protected head
 // as "kid" field value. Otherwise, JWK is computed using jwkEncode and inserted
 // as "jwk" field value. The "jwk" and "kid" fields are mutually exclusive.
+//
+// If nonce is non-empty, its quoted value is inserted in the protected head.
 //
 // See https://tools.ietf.org/html/rfc7515#section-7.
 func jwsEncodeJSON(claimset interface{}, key crypto.Signer, kid KeyID, nonce, url string) ([]byte, error) {
@@ -58,20 +67,36 @@ func jwsEncodeJSON(claimset interface{}, key crypto.Signer, kid KeyID, nonce, ur
 	if alg == "" || !sha.Available() {
 		return nil, ErrUnsupportedKey
 	}
-	var phead string
+	headers := struct {
+		Alg   string          `json:"alg"`
+		KID   string          `json:"kid,omitempty"`
+		JWK   json.RawMessage `json:"jwk,omitempty"`
+		Nonce string          `json:"nonce,omitempty"`
+		URL   string          `json:"url"`
+	}{
+		Alg:   alg,
+		Nonce: nonce,
+		URL:   url,
+	}
 	switch kid {
 	case noKeyID:
 		jwk, err := jwkEncode(key.Public())
 		if err != nil {
 			return nil, err
 		}
-		phead = fmt.Sprintf(`{"alg":%q,"jwk":%s,"nonce":%q,"url":%q}`, alg, jwk, nonce, url)
+		headers.JWK = json.RawMessage(jwk)
 	default:
-		phead = fmt.Sprintf(`{"alg":%q,"kid":%q,"nonce":%q,"url":%q}`, alg, kid, nonce, url)
+		headers.KID = string(kid)
 	}
-	phead = base64.RawURLEncoding.EncodeToString([]byte(phead))
+	phJSON, err := json.Marshal(headers)
+	if err != nil {
+		return nil, err
+	}
+	phead := base64.RawURLEncoding.EncodeToString([]byte(phJSON))
 	var payload string
-	if claimset != noPayload {
+	if val, ok := claimset.(string); ok {
+		payload = val
+	} else {
 		cs, err := json.Marshal(claimset)
 		if err != nil {
 			return nil, err

--- a/acme/rfc8555.go
+++ b/acme/rfc8555.go
@@ -148,6 +148,42 @@ func responseAccount(res *http.Response) (*Account, error) {
 	}, nil
 }
 
+// Attempt to perform account key rollover.
+// On success it will change client.Key to the new key.
+func (c *Client) accountKeyRollover(ctx context.Context, newKey crypto.Signer) error {
+	dir, err := c.Discover(ctx) // Also required by c.accountKID
+	if err != nil {
+		return err
+	}
+	kid := c.accountKID(ctx)
+	if kid == noKeyID {
+		return ErrNoAccount
+	}
+	oldKey, err := jwkEncode(c.Key.Public())
+	if err != nil {
+		return err
+	}
+	payload := struct {
+		Account string          `json:"account"`
+		OldKey  json.RawMessage `json:"oldKey"`
+	}{
+		Account: string(kid),
+		OldKey:  json.RawMessage(oldKey),
+	}
+	inner, err := jwsEncodeJSON(payload, newKey, noKeyID, noNonce, dir.KeyChangeURL)
+	if err != nil {
+		return err
+	}
+
+	res, err := c.post(ctx, nil, dir.KeyChangeURL, base64.RawURLEncoding.EncodeToString(inner), wantStatus(http.StatusOK))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	c.Key = newKey
+	return nil
+}
+
 // AuthorizeOrder initiates the order-based application for certificate issuance,
 // as opposed to pre-authorization in Authorize.
 // It is only supported by CAs implementing RFC 8555.


### PR DESCRIPTION
Add support for AccountKeyRollover. API only returns an error since acme.Error
will contain appropriate KID lookup information. Due to the requirements
of double JWS encoding jwsEncodeJSON is also modified to support a
missing Nonce header and raw string embedding in the payload.

Fixes golang/go#42516