### PR TITLE
ssh: add MultiAlgorithmSigner

### DIFF
--- a/ssh/certs.go
+++ b/ssh/certs.go
@@ -288,14 +288,14 @@ func (s *multiAlgorithmSSHCertSigner) Algorithms() []string {
 // The algorithms must be set in preference order.
 // An error is returned if the specified algorithms are incompatible with the
 // public key type.
-func NewSignerWithAlgorithms(signer AlgorithmSigner, algorithms []string) (Signer, error) {
+func NewSignerWithAlgorithms(signer AlgorithmSigner, algorithms []string) (MultiAlgorithmSigner, error) {
 	if len(algorithms) == 0 {
 		return nil, errors.New("ssh: please specify at least one valid signing algorithms")
 	}
 	supportedAlgos := algorithmsForKeyFormat(signer.PublicKey().Type())
 	for _, algo := range algorithms {
 		if !contains(supportedAlgos, algo) {
-			return signer, fmt.Errorf("ssh: algorithm %s is not supported for key type %s",
+			return nil, fmt.Errorf("ssh: algorithm %s is not supported for key type %s",
 				algo, signer.PublicKey().Type())
 		}
 	}

--- a/ssh/certs.go
+++ b/ssh/certs.go
@@ -284,11 +284,11 @@ func (s *multiAlgorithmSSHCertSigner) Algorithms() []string {
 	return s.supportedAlgorithms
 }
 
-// NewSignerWithAlgos returns a signer restricted to the specified algorithms.
+// NewSignerWithAlgorithms returns a signer restricted to the specified algorithms.
 // The algorithms must be set in preference order.
 // An error is returned if the specified algorithms are incompatible with the
 // public key type.
-func NewSignerWithAlgos(signer AlgorithmSigner, algorithms []string) (Signer, error) {
+func NewSignerWithAlgorithms(signer AlgorithmSigner, algorithms []string) (Signer, error) {
 	if len(algorithms) == 0 {
 		return nil, errors.New("ssh: please specify at least one valid signing algorithms")
 	}

--- a/ssh/certs_test.go
+++ b/ssh/certs_test.go
@@ -246,7 +246,7 @@ func TestCertTypes(t *testing.T) {
 	if !ok {
 		t.Fatal("rsa test signer does not implement the AlgorithmSigner interface")
 	}
-	multiAlgoSigner, err := NewSignerWithAlgos(algorithSigner, []string{KeyAlgoRSASHA256})
+	multiAlgoSigner, err := NewSignerWithAlgorithms(algorithSigner, []string{KeyAlgoRSASHA256})
 	if err != nil {
 		t.Fatalf("unable to create multi algorithm signer: %v", err)
 	}
@@ -333,17 +333,17 @@ func TestNewSignerWithAlgos(t *testing.T) {
 	if !ok {
 		t.Fatal("rsa test signer does not implement the AlgorithmSigner interface")
 	}
-	_, err := NewSignerWithAlgos(algorithSigner, nil)
+	_, err := NewSignerWithAlgorithms(algorithSigner, nil)
 	if err == nil {
 		t.Error("signer with algos created with no algorithms")
 	}
 
-	_, err = NewSignerWithAlgos(algorithSigner, []string{KeyAlgoED25519})
+	_, err = NewSignerWithAlgorithms(algorithSigner, []string{KeyAlgoED25519})
 	if err == nil {
 		t.Error("signer with algos created with invalid algorithms")
 	}
 
-	_, err = NewSignerWithAlgos(algorithSigner, []string{KeyAlgoRSASHA256, KeyAlgoRSASHA512})
+	_, err = NewSignerWithAlgorithms(algorithSigner, []string{KeyAlgoRSASHA256, KeyAlgoRSASHA512})
 	if err != nil {
 		t.Errorf("unable to create signer with valid algorithms: %v", err)
 	}

--- a/ssh/handshake_test.go
+++ b/ssh/handshake_test.go
@@ -624,7 +624,7 @@ func TestMultiSignerHandshake(t *testing.T) {
 	if !ok {
 		t.Fatal("rsa test signer does not implement the AlgorithmSigner interface")
 	}
-	multiAlgoSigner, err := NewSignerWithAlgos(algorithSigner, []string{KeyAlgoRSASHA256, KeyAlgoRSASHA512})
+	multiAlgoSigner, err := NewSignerWithAlgorithms(algorithSigner, []string{KeyAlgoRSASHA256, KeyAlgoRSASHA512})
 	if err != nil {
 		t.Fatalf("unable to create multi algorithm signer: %v", err)
 	}
@@ -660,7 +660,7 @@ func TestMultiSignerNoCommonHostKeyAlgo(t *testing.T) {
 	if !ok {
 		t.Fatal("rsa test signer does not implement the AlgorithmSigner interface")
 	}
-	multiAlgoSigner, err := NewSignerWithAlgos(algorithSigner, []string{KeyAlgoRSASHA256, KeyAlgoRSASHA512})
+	multiAlgoSigner, err := NewSignerWithAlgorithms(algorithSigner, []string{KeyAlgoRSASHA256, KeyAlgoRSASHA512})
 	if err != nil {
 		t.Fatalf("unable to create multi algorithm signer: %v", err)
 	}

--- a/ssh/handshake_test.go
+++ b/ssh/handshake_test.go
@@ -618,3 +618,78 @@ func TestNoSHA2Support(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMultiSignerHandshake(t *testing.T) {
+	algorithSigner, ok := testSigners["rsa"].(AlgorithmSigner)
+	if !ok {
+		t.Fatal("rsa test signer does not implement the AlgorithmSigner interface")
+	}
+	multiAlgoSigner, err := NewSignerWithAlgos(algorithSigner, []string{KeyAlgoRSASHA256, KeyAlgoRSASHA512})
+	if err != nil {
+		t.Fatalf("unable to create multi algorithm signer: %v", err)
+	}
+	c1, c2, err := netPipe()
+	if err != nil {
+		t.Fatalf("netPipe: %v", err)
+	}
+	defer c1.Close()
+	defer c2.Close()
+
+	serverConf := &ServerConfig{
+		PasswordCallback: func(conn ConnMetadata, password []byte) (*Permissions, error) {
+			return &Permissions{}, nil
+		},
+	}
+	serverConf.AddHostKey(multiAlgoSigner)
+	go NewServerConn(c1, serverConf)
+
+	clientConf := &ClientConfig{
+		User:              "test",
+		Auth:              []AuthMethod{Password("testpw")},
+		HostKeyCallback:   FixedHostKey(testSigners["rsa"].PublicKey()),
+		HostKeyAlgorithms: []string{KeyAlgoRSASHA512},
+	}
+
+	if _, _, _, err := NewClientConn(c2, "", clientConf); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMultiSignerNoCommonHostKeyAlgo(t *testing.T) {
+	algorithSigner, ok := testSigners["rsa"].(AlgorithmSigner)
+	if !ok {
+		t.Fatal("rsa test signer does not implement the AlgorithmSigner interface")
+	}
+	multiAlgoSigner, err := NewSignerWithAlgos(algorithSigner, []string{KeyAlgoRSASHA256, KeyAlgoRSASHA512})
+	if err != nil {
+		t.Fatalf("unable to create multi algorithm signer: %v", err)
+	}
+	c1, c2, err := netPipe()
+	if err != nil {
+		t.Fatalf("netPipe: %v", err)
+	}
+	defer c1.Close()
+	defer c2.Close()
+
+	// ssh-rsa is disabled server side
+	serverConf := &ServerConfig{
+		PasswordCallback: func(conn ConnMetadata, password []byte) (*Permissions, error) {
+			return &Permissions{}, nil
+		},
+	}
+	serverConf.AddHostKey(multiAlgoSigner)
+	go NewServerConn(c1, serverConf)
+
+	// the client only supports ssh-rsa
+	clientConf := &ClientConfig{
+		User:              "test",
+		Auth:              []AuthMethod{Password("testpw")},
+		HostKeyCallback:   FixedHostKey(testSigners["rsa"].PublicKey()),
+		HostKeyAlgorithms: []string{KeyAlgoRSA},
+	}
+
+	_, _, _, err = NewClientConn(c2, "", clientConf)
+	if err == nil {
+		t.Fatal("succeeded connecting with no common hostkey algorithm")
+	}
+}

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -349,6 +349,15 @@ type AlgorithmSigner interface {
 	SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*Signature, error)
 }
 
+// MultiAlgorithmSigner is an AlgorithmSigner that also reports the algorithms
+// supported by that signer
+type MultiAlgorithmSigner interface {
+	AlgorithmSigner
+
+	// Algorithms returns the available algorithms in preference order
+	Algorithms() []string
+}
+
 type rsaPublicKey rsa.PublicKey
 
 func (r *rsaPublicKey) Type() string {


### PR DESCRIPTION
MultiAlgorithmSigner allows to restrict signature algorithms.

Fixes #52132 #36261