### PR TITLE
Update client.go

### DIFF
--- a/ssh/client.go
+++ b/ssh/client.go
@@ -138,6 +138,16 @@ func (c *Client) NewSession() (*Session, error) {
 	return newSession(ch, in)
 }
 
+func (c *Client) NewSessionAndChannel() (*Session, Channel, <-chan *Request, error) {
+	ch, in, err := c.OpenChannel("session", nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	session, err := newSession(ch, in)
+	return session, ch, in, err
+}
+
 func (c *Client) handleGlobalRequests(incoming <-chan *Request) {
 	for r := range incoming {
 		// This handles keepalive messages and matches


### PR DESCRIPTION
Client.NewSession方法仅仅返回了Session，而打开的channel通道却没有用武之地，且使用方无法获取到该通道，因为是私有属性，如果想要使用channel，需要再次调用openChanne()方法。本人进行服务器和交换机ssh远程登录时，使用到了该源码，服务器可以正常使用，但交换机只能一个Session一个Channel。本人添加NewSessionAndChannel()方法将Session中的channel及request一并返回，使用该channel与交换机及服务器都能正常通信。