### PR TITLE
Update client.go

### DIFF
--- a/ssh/client.go
+++ b/ssh/client.go
@@ -138,6 +138,16 @@ func (c *Client) NewSession() (*Session, error) {
 	return newSession(ch, in)
 }
 
+func (c *Client) NewSessionAndChannel() (*Session, Channel, <-chan *Request, error) {
+	ch, in, err := c.OpenChannel("session", nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	session, err := newSession(ch, in)
+	return session, ch, in, err
+}
+
 func (c *Client) handleGlobalRequests(incoming <-chan *Request) {
 	for r := range incoming {
 		// This handles keepalive messages and matches


### PR DESCRIPTION
The Client.NewSession method only returns the Session, but the opened channel is useless, and the user cannot obtain the channel because it is a private property. If you want to use the channel, you need to call the openChanne() method again. When I log in to the server and the switch ssh remotely, I use this source code, the server can be used normally, but the switch can only have one Session and one Channel, and cannot open another channel again. I add the NewSessionAndChannel() method to return the channel and request in the Session together, and use the channel to communicate with the switch and the server normally.