### PR TITLE
cryptobyte: AddUint*LengthPrefixed API perfomance optimization

### DIFF
--- a/cryptobyte/builder.go
+++ b/cryptobyte/builder.go
@@ -24,16 +24,11 @@ type Builder struct {
 	err    error
 	result []byte
 
-	builderContinuationData
+	offset        int
+	pendingLenLen int
 
 	fixedSize      bool
 	inContinuation bool
-}
-
-type builderContinuationData struct {
-	offset        int
-	pendingLenLen int
-	pendingIsASN1 bool
 }
 
 // NewBuilder creates a Builder that appends its output to the given buffer.
@@ -188,15 +183,16 @@ func (b *Builder) addLengthPrefixed(lenLen int, isASN1 bool, f BuilderContinuati
 	offset := len(b.result)
 	b.alloc(lenLen)
 
-	before := b.builderContinuationData
+	beforeOffset := b.offset
+	beforelenLen := b.pendingLenLen
 
 	b.offset = offset
 	b.pendingLenLen = lenLen
-	b.pendingIsASN1 = isASN1
 
 	b.callContinuation(f, b)
 
-	b.builderContinuationData = before
+	b.offset = beforeOffset
+	b.pendingLenLen = beforelenLen
 
 	if b.err != nil {
 		return

--- a/cryptobyte/cryptobyte_test.go
+++ b/cryptobyte/cryptobyte_test.go
@@ -11,6 +11,39 @@ import (
 	"testing"
 )
 
+func BenchmarkLenghtPrefixed(b *testing.B) {
+	buf := make([]byte, 0, 512)
+
+	for i := 0; i < b.N; i++ {
+		a := NewBuilder(buf)
+		a.AddUint8LengthPrefixed(func(b *Builder) {
+			b.AddBytes([]byte("123456"))
+			b.AddUint8LengthPrefixed(func(b *Builder) {
+				b.AddBytes([]byte("123456"))
+			})
+			b.AddUint8LengthPrefixed(func(b *Builder) {
+				b.AddBytes([]byte("123456"))
+			})
+			b.AddUint8LengthPrefixed(func(b *Builder) {
+				b.AddBytes([]byte("123456"))
+			})
+		})
+		a.AddUint8LengthPrefixed(func(b *Builder) {
+			b.AddBytes([]byte("123456"))
+			b.AddUint8LengthPrefixed(func(b *Builder) {
+				b.AddBytes([]byte("123456"))
+			})
+		})
+		a.AddUint8LengthPrefixed(func(b *Builder) {
+			b.AddBytes([]byte("123456"))
+			b.AddUint8LengthPrefixed(func(b *Builder) {
+				b.AddBytes([]byte("123456"))
+			})
+		})
+
+	}
+}
+
 func builderBytesEq(b *Builder, want ...byte) error {
 	got := b.BytesOrPanic()
 	if !bytes.Equal(got, want) {
@@ -321,36 +354,6 @@ func TestPreallocatedBuffer(t *testing.T) {
 	if err := builderBytesEq(b, 1, 2, 3, 4, 5, 6); err != nil {
 		t.Error(err)
 	}
-}
-
-func TestWriteWithPendingChild(t *testing.T) {
-	var b Builder
-	b.AddUint8LengthPrefixed(func(c *Builder) {
-		c.AddUint8LengthPrefixed(func(d *Builder) {
-			func() {
-				defer func() {
-					if recover() == nil {
-						t.Errorf("recover() = nil, want error; c.AddUint8() did not panic")
-					}
-				}()
-				c.AddUint8(2) // panics
-			}()
-
-			defer func() {
-				if recover() == nil {
-					t.Errorf("recover() = nil, want error; b.AddUint8() did not panic")
-				}
-			}()
-			b.AddUint8(2) // panics
-		})
-
-		defer func() {
-			if recover() == nil {
-				t.Errorf("recover() = nil, want error; b.AddUint8() did not panic")
-			}
-		}()
-		b.AddUint8(2) // panics
-	})
 }
 
 func TestSetError(t *testing.T) {

--- a/cryptobyte/cryptobyte_test.go
+++ b/cryptobyte/cryptobyte_test.go
@@ -40,7 +40,6 @@ func BenchmarkLenghtPrefixed(b *testing.B) {
 				b.AddBytes([]byte("123456"))
 			})
 		})
-
 	}
 }
 


### PR DESCRIPTION
benchmark                     old ns/op     new ns/op     delta
BenchmarkLenghtPrefixed-4     1345          265           -80.27%

benchmark                     old allocs     new allocs     delta
BenchmarkLenghtPrefixed-4     17             1              -94.12%

benchmark                     old bytes     new bytes     delta
BenchmarkLenghtPrefixed-4     777           64            -91.76%

Fixes: golang/go#54059