### PR TITLE
all: use crypto/ed25519 instead of golang.org/x/crypto/ed25519

### DIFF
--- a/internal/wycheproof/eddsa_test.go
+++ b/internal/wycheproof/eddsa_test.go
@@ -8,9 +8,8 @@
 package wycheproof
 
 import (
+	"crypto/ed25519"
 	"testing"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 func TestEddsa(t *testing.T) {

--- a/nacl/sign/sign.go
+++ b/nacl/sign/sign.go
@@ -21,9 +21,9 @@
 package sign
 
 import (
+	"crypto/ed25519"
 	"io"
 
-	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/internal/alias"
 )
 

--- a/ssh/agent/client.go
+++ b/ssh/agent/client.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rsa"
 	"encoding/base64"
@@ -26,7 +27,6 @@ import (
 	"math/big"
 	"sync"
 
-	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/ssh"
 )
 

--- a/ssh/agent/server.go
+++ b/ssh/agent/server.go
@@ -7,6 +7,7 @@ package agent
 import (
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rsa"
 	"encoding/binary"
@@ -16,7 +17,6 @@ import (
 	"log"
 	"math/big"
 
-	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/ssh"
 )
 

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -11,6 +11,7 @@ import (
 	"crypto/cipher"
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/md5"
 	"crypto/rand"
@@ -28,7 +29,6 @@ import (
 	"math/big"
 	"strings"
 
-	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/ssh/internal/bcrypt_pbkdf"
 )
 

--- a/ssh/keys_test.go
+++ b/ssh/keys_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -21,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/ssh/testdata"
 )
 


### PR DESCRIPTION
This is a follow-up to CL 317169, which dropped go1.12 compatibility,
and made the golang.org/x/crypto/ed25519 package an alias / wrapper for
crypto/ed25519 in stdlib.

This patch updates uses within this repository to use stdlib instead of
depending on the wrapper. With this patch applied, the only remaining
use of the wrapper is in ed25519_test, which appears to be in place to
verify compatibility of the wrapper itself.
