### PR TITLE
chacha20: drop Go 1.10 compatibility for arm64

### DIFF
--- a/chacha20/chacha_arm64.go
+++ b/chacha20/chacha_arm64.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build go1.11 && gc && !purego
-// +build go1.11,gc,!purego
+//go:build gc && !purego
+// +build gc,!purego
 
 package chacha20
 

--- a/chacha20/chacha_arm64.s
+++ b/chacha20/chacha_arm64.s
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build go1.11 && gc && !purego
-// +build go1.11,gc,!purego
+//go:build gc && !purego
+// +build gc,!purego
 
 #include "textflag.h"
 

--- a/chacha20/chacha_noasm.go
+++ b/chacha20/chacha_noasm.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build (!arm64 && !s390x && !ppc64le) || (arm64 && !go1.11) || !gc || purego
-// +build !arm64,!s390x,!ppc64le arm64,!go1.11 !gc purego
+//go:build (!arm64 && !s390x && !ppc64le) || !gc || purego
+// +build !arm64,!s390x,!ppc64le !gc purego
 
 package chacha20
 


### PR DESCRIPTION
Other packages already dropped compatibility with go < 1.12, so it should be safe to remove it for this package as well.
