### PR TITLE
ssh: report disconnect messages as public error type from Conn.Wait

### DIFF
--- a/ssh/client_auth_test.go
+++ b/ssh/client_auth_test.go
@@ -613,7 +613,7 @@ func TestClientAuthMaxAuthTries(t *testing.T) {
 	}
 	serverConfig.AddHostKey(testSigners["rsa"])
 
-	expectedErr := fmt.Errorf("ssh: handshake failed: %v", &disconnectMsg{
+	expectedErr := fmt.Errorf("ssh: handshake failed: %v", &DisconnectError{
 		Reason:  2,
 		Message: "too many authentication failures",
 	})
@@ -676,7 +676,7 @@ func TestClientAuthMaxAuthTriesPublicKey(t *testing.T) {
 		t.Fatalf("unable to dial remote side: %s", err)
 	}
 
-	expectedErr := fmt.Errorf("ssh: handshake failed: %v", &disconnectMsg{
+	expectedErr := fmt.Errorf("ssh: handshake failed: %v", &DisconnectError{
 		Reason:  2,
 		Message: "too many authentication failures",
 	})

--- a/ssh/handshake_test.go
+++ b/ssh/handshake_test.go
@@ -505,11 +505,15 @@ func TestDisconnect(t *testing.T) {
 	defer trS.Close()
 
 	trC.writePacket([]byte{msgRequestSuccess, 0, 0})
-	errMsg := &disconnectMsg{
+	errPacket := &disconnectMsg{
 		Reason:  42,
 		Message: "such is life",
 	}
-	trC.writePacket(Marshal(errMsg))
+	errResponse := &DisconnectError{
+		Reason:  DisconnectReason(errPacket.Reason),
+		Message: errPacket.Message,
+	}
+	trC.writePacket(Marshal(errPacket))
 	trC.writePacket([]byte{msgRequestSuccess, 0, 0})
 
 	packet, err := trS.readPacket()
@@ -523,8 +527,8 @@ func TestDisconnect(t *testing.T) {
 	_, err = trS.readPacket()
 	if err == nil {
 		t.Errorf("readPacket 2 succeeded")
-	} else if !reflect.DeepEqual(err, errMsg) {
-		t.Errorf("got error %#v, want %#v", err, errMsg)
+	} else if !reflect.DeepEqual(err, errResponse) {
+		t.Errorf("got error %#v, want %#v", err, errResponse)
 	}
 
 	_, err = trS.readPacket()

--- a/ssh/messages.go
+++ b/ssh/messages.go
@@ -43,10 +43,6 @@ type disconnectMsg struct {
 	Language string
 }
 
-func (d *disconnectMsg) Error() string {
-	return fmt.Sprintf("ssh: disconnect, reason %d: %s", d.Reason, d.Message)
-}
-
 // See RFC 4253, section 7.1.
 const msgKexInit = 20
 

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -416,7 +416,8 @@ userAuthLoop:
 				return nil, err
 			}
 
-			return nil, discMsg
+			err := &DisconnectError{Reason: DisconnectReason(discMsg.Reason), Message: discMsg.Message}
+			return nil, err
 		}
 
 		var userAuthReq userAuthRequestMsg

--- a/ssh/transport.go
+++ b/ssh/transport.go
@@ -154,7 +154,8 @@ func (s *connectionState) readPacket(r *bufio.Reader) ([]byte, error) {
 			if err := Unmarshal(packet, &msg); err != nil {
 				return nil, err
 			}
-			return nil, &msg
+			err := &DisconnectError{Reason: DisconnectReason(msg.Reason), Message: msg.Message}
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Replaces internal and external use of `disconnectMsg` as an error type for reporting back disconnects with a new public `ssh.DisconnectError` type.

This makes it possible to extract the disconnect reason code programmatically, and respond appropriately.

See https://github.com/golang/go/issues/39259 for suggestion to export disconnect error message type.
Related https://github.com/golang/go/issues/37913 for sending disconnect messages.