### PR TITLE
all: use error wrap when possible

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -373,7 +373,7 @@ func (c *Client) authorize(ctx context.Context, typ, val string) (*Authorization
 
 	var v wireAuthz
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
-		return nil, fmt.Errorf("acme: invalid response: %v", err)
+		return nil, fmt.Errorf("acme: invalid response: %w", err)
 	}
 	if v.Status != StatusPending && v.Status != StatusValid {
 		return nil, fmt.Errorf("acme: unexpected status: %s", v.Status)
@@ -397,7 +397,7 @@ func (c *Client) GetAuthorization(ctx context.Context, url string) (*Authorizati
 	defer res.Body.Close()
 	var v wireAuthz
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
-		return nil, fmt.Errorf("acme: invalid response: %v", err)
+		return nil, fmt.Errorf("acme: invalid response: %w", err)
 	}
 	return v.authorization(url), nil
 }
@@ -500,7 +500,7 @@ func (c *Client) GetChallenge(ctx context.Context, url string) (*Challenge, erro
 	defer res.Body.Close()
 	v := wireChallenge{URI: url}
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
-		return nil, fmt.Errorf("acme: invalid response: %v", err)
+		return nil, fmt.Errorf("acme: invalid response: %w", err)
 	}
 	return v.challenge(), nil
 }
@@ -525,7 +525,7 @@ func (c *Client) Accept(ctx context.Context, chal *Challenge) (*Challenge, error
 
 	var v wireChallenge
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
-		return nil, fmt.Errorf("acme: invalid response: %v", err)
+		return nil, fmt.Errorf("acme: invalid response: %w", err)
 	}
 	return v.challenge(), nil
 }

--- a/acme/autocert/internal/acmetest/ca.go
+++ b/acme/autocert/internal/acmetest/ca.go
@@ -467,7 +467,7 @@ func (ca *CAServer) handle(w http.ResponseWriter, r *http.Request) {
 func (ca *CAServer) storedOrder(i string) (*order, error) {
 	idx, err := strconv.Atoi(i)
 	if err != nil {
-		return nil, fmt.Errorf("storedOrder: %v", err)
+		return nil, fmt.Errorf("storedOrder: %w", err)
 	}
 	if idx < 0 {
 		return nil, fmt.Errorf("storedOrder: invalid order index %d", idx)
@@ -485,7 +485,7 @@ func (ca *CAServer) storedOrder(i string) (*order, error) {
 func (ca *CAServer) storedAuthz(i string) (*authorization, error) {
 	idx, err := strconv.Atoi(i)
 	if err != nil {
-		return nil, fmt.Errorf("storedAuthz: %v", err)
+		return nil, fmt.Errorf("storedAuthz: %w", err)
 	}
 	if idx < 0 {
 		return nil, fmt.Errorf("storedAuthz: invalid authz index %d", idx)
@@ -700,7 +700,7 @@ func (ca *CAServer) verifyALPNChallenge(a *authorization) error {
 	}
 
 	if err := crt.VerifyHostname(a.domain); err != nil {
-		return fmt.Errorf("verifyALPNChallenge: VerifyHostname: %v", err)
+		return fmt.Errorf("verifyALPNChallenge: VerifyHostname: %w", err)
 	}
 	// See RFC 8737, Section 6.1.
 	oid := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 31}

--- a/acme/internal/acmeprobe/prober.go
+++ b/acme/internal/acmeprobe/prober.go
@@ -301,7 +301,7 @@ func (p *prober) fulfill(ctx context.Context, z *acme.Authorization) error {
 func (p *prober) runTLSALPN01(ctx context.Context, z *acme.Authorization, chal *acme.Challenge) error {
 	tokenCert, err := p.client.TLSALPN01ChallengeCert(chal.Token, z.Identifier.Value)
 	if err != nil {
-		return fmt.Errorf("TLSALPN01ChallengeCert: %v", err)
+		return fmt.Errorf("TLSALPN01ChallengeCert: %w", err)
 	}
 	s := &http.Server{
 		Addr: p.localAddr,
@@ -321,7 +321,7 @@ func (p *prober) runTLSALPN01(ctx context.Context, z *acme.Authorization, chal *
 	defer s.Close()
 
 	if _, err := p.client.Accept(ctx, chal); err != nil {
-		return fmt.Errorf("Accept(%q): %v", chal.URI, err)
+		return fmt.Errorf("Accept(%q): %w", chal.URI, err)
 	}
 	_, zerr := p.client.WaitAuthorization(ctx, z.URI)
 	return zerr
@@ -330,7 +330,7 @@ func (p *prober) runTLSALPN01(ctx context.Context, z *acme.Authorization, chal *
 func (p *prober) runHTTP01(ctx context.Context, z *acme.Authorization, chal *acme.Challenge) error {
 	body, err := p.client.HTTP01ChallengeResponse(chal.Token)
 	if err != nil {
-		return fmt.Errorf("HTTP01ChallengeResponse: %v", err)
+		return fmt.Errorf("HTTP01ChallengeResponse: %w", err)
 	}
 	s := &http.Server{
 		Addr: p.localAddr,
@@ -347,7 +347,7 @@ func (p *prober) runHTTP01(ctx context.Context, z *acme.Authorization, chal *acm
 	defer s.Close()
 
 	if _, err := p.client.Accept(ctx, chal); err != nil {
-		return fmt.Errorf("Accept(%q): %v", chal.URI, err)
+		return fmt.Errorf("Accept(%q): %w", chal.URI, err)
 	}
 	_, zerr := p.client.WaitAuthorization(ctx, z.URI)
 	return zerr
@@ -356,7 +356,7 @@ func (p *prober) runHTTP01(ctx context.Context, z *acme.Authorization, chal *acm
 func (p *prober) runDNS01(ctx context.Context, z *acme.Authorization, chal *acme.Challenge) error {
 	token, err := p.client.DNS01ChallengeRecord(chal.Token)
 	if err != nil {
-		return fmt.Errorf("DNS01ChallengeRecord: %v", err)
+		return fmt.Errorf("DNS01ChallengeRecord: %w", err)
 	}
 
 	name := fmt.Sprintf("_acme-challenge.%s", z.Identifier.Value)
@@ -365,11 +365,11 @@ func (p *prober) runDNS01(ctx context.Context, z *acme.Authorization, chal *acme
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%s: %v", p.dnsScript, err)
+		return fmt.Errorf("%s: %w", p.dnsScript, err)
 	}
 
 	if _, err := p.client.Accept(ctx, chal); err != nil {
-		return fmt.Errorf("Accept(%q): %v", chal.URI, err)
+		return fmt.Errorf("Accept(%q): %w", chal.URI, err)
 	}
 	_, zerr := p.client.WaitAuthorization(ctx, z.URI)
 	return zerr
@@ -389,7 +389,7 @@ func checkCert(derChain [][]byte, id []acme.AuthzID) error {
 	for i, b := range derChain {
 		crt, err := x509.ParseCertificate(b)
 		if err != nil {
-			return fmt.Errorf("%d: ParseCertificate: %v", i, err)
+			return fmt.Errorf("%d: ParseCertificate: %w", i, err)
 		}
 		log.Printf("%d: serial: 0x%s", i, crt.SerialNumber)
 		log.Printf("%d: subject: %s", i, crt.Subject)

--- a/acme/rfc8555.go
+++ b/acme/rfc8555.go
@@ -60,7 +60,7 @@ func (c *Client) registerRFC(ctx context.Context, acct *Account, prompt func(tos
 	if acct.ExternalAccountBinding != nil {
 		eabJWS, err := c.encodeExternalAccountBinding(acct.ExternalAccountBinding)
 		if err != nil {
-			return nil, fmt.Errorf("acme: failed to encode external account binding: %v", err)
+			return nil, fmt.Errorf("acme: failed to encode external account binding: %w", err)
 		}
 		req.ExternalAccountBinding = eabJWS
 	}
@@ -140,7 +140,7 @@ func responseAccount(res *http.Response) (*Account, error) {
 		Orders  string
 	}
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
-		return nil, fmt.Errorf("acme: invalid account response: %v", err)
+		return nil, fmt.Errorf("acme: invalid account response: %w", err)
 	}
 	return &Account{
 		URI:       res.Header.Get("Location"),
@@ -307,7 +307,7 @@ func responseOrder(res *http.Response) (*Order, error) {
 		Certificate    string
 	}
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
-		return nil, fmt.Errorf("acme: error reading order: %v", err)
+		return nil, fmt.Errorf("acme: error reading order: %w", err)
 	}
 	o := &Order{
 		URI:         res.Header.Get("Location"),
@@ -391,7 +391,7 @@ func (c *Client) fetchCertRFC(ctx context.Context, url string, bundle bool) ([][
 	const max = maxCertChainSize + maxCertChainSize/33
 	b, err := io.ReadAll(io.LimitReader(res.Body, max+1))
 	if err != nil {
-		return nil, fmt.Errorf("acme: fetch cert response stream: %v", err)
+		return nil, fmt.Errorf("acme: fetch cert response stream: %w", err)
 	}
 	if len(b) > max {
 		return nil, errors.New("acme: certificate chain is too big")
@@ -469,7 +469,7 @@ func (c *Client) ListCertAlternates(ctx context.Context, url string) ([]string, 
 	// We don't need the body but we need to discard it so we don't end up
 	// preventing keep-alive
 	if _, err := io.Copy(io.Discard, res.Body); err != nil {
-		return nil, fmt.Errorf("acme: cert alternates response stream: %v", err)
+		return nil, fmt.Errorf("acme: cert alternates response stream: %w", err)
 	}
 	alts := linkHeader(res.Header, "alternate")
 	return alts, nil

--- a/ssh/agent/client.go
+++ b/ssh/agent/client.go
@@ -240,7 +240,7 @@ type Key struct {
 }
 
 func clientErr(err error) error {
-	return fmt.Errorf("agent: client error: %v", err)
+	return fmt.Errorf("agent: client error: %w", err)
 }
 
 // String returns the storage form of an agent key with the format, base64
@@ -269,7 +269,7 @@ func (k *Key) Marshal() []byte {
 func (k *Key) Verify(data []byte, sig *ssh.Signature) error {
 	pubKey, err := ssh.ParsePublicKey(k.Blob)
 	if err != nil {
-		return fmt.Errorf("agent: bad public key: %v", err)
+		return fmt.Errorf("agent: bad public key: %w", err)
 	}
 	return pubKey.Verify(data, sig)
 }

--- a/ssh/agent/server.go
+++ b/ssh/agent/server.go
@@ -387,7 +387,7 @@ func parseRSACert(req []byte) (*AddedKey, error) {
 		N    *big.Int
 	}
 	if err := ssh.Unmarshal(cert.Key.Marshal(), &rsaPub); err != nil {
-		return nil, fmt.Errorf("agent: Unmarshal failed to parse public key: %v", err)
+		return nil, fmt.Errorf("agent: Unmarshal failed to parse public key: %w", err)
 	}
 
 	if rsaPub.E.BitLen() > 30 {
@@ -431,7 +431,7 @@ func parseDSACert(req []byte) (*AddedKey, error) {
 		P, Q, G, Y *big.Int
 	}
 	if err := ssh.Unmarshal(cert.Key.Marshal(), &w); err != nil {
-		return nil, fmt.Errorf("agent: Unmarshal failed to parse public key: %v", err)
+		return nil, fmt.Errorf("agent: Unmarshal failed to parse public key: %w", err)
 	}
 
 	priv := &dsa.PrivateKey{

--- a/ssh/client.go
+++ b/ssh/client.go
@@ -82,7 +82,7 @@ func NewClientConn(c net.Conn, addr string, config *ClientConfig) (Conn, <-chan 
 
 	if err := conn.clientHandshake(addr, &fullConf); err != nil {
 		c.Close()
-		return nil, nil, nil, fmt.Errorf("ssh: handshake failed: %v", err)
+		return nil, nil, nil, fmt.Errorf("ssh: handshake failed: %w", err)
 	}
 	conn.mux = newMux(conn.transport)
 	return conn, conn.mux.incomingChannels, conn.mux.incomingRequests, nil

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -1139,7 +1139,7 @@ func ParseRawPrivateKeyWithPassphrase(pemBytes, passphrase []byte) (interface{},
 		if err == x509.IncorrectPasswordError {
 			return nil, err
 		}
-		return nil, fmt.Errorf("ssh: cannot decode encrypted private keys: %v", err)
+		return nil, fmt.Errorf("ssh: cannot decode encrypted private keys: %w", err)
 	}
 
 	switch block.Type {
@@ -1277,7 +1277,7 @@ func parseOpenSSHPrivateKey(key []byte, decrypt openSSHDecryptFunc) (crypto.Priv
 		if err, ok := err.(*PassphraseMissingError); ok {
 			pub, errPub := ParsePublicKey(w.PubKey)
 			if errPub != nil {
-				return nil, fmt.Errorf("ssh: failed to parse embedded public key: %v", errPub)
+				return nil, fmt.Errorf("ssh: failed to parse embedded public key: %w", errPub)
 			}
 			err.PublicKey = pub
 		}

--- a/ssh/knownhosts/knownhosts.go
+++ b/ssh/knownhosts/knownhosts.go
@@ -333,7 +333,7 @@ func (db *hostKeyDB) check(address string, remote net.Addr, remoteKey ssh.Public
 
 	host, port, err := net.SplitHostPort(remote.String())
 	if err != nil {
-		return fmt.Errorf("knownhosts: SplitHostPort(%s): %v", remote, err)
+		return fmt.Errorf("knownhosts: SplitHostPort(%s): %w", remote, err)
 	}
 
 	hostToCheck := addr{host, port}
@@ -341,7 +341,7 @@ func (db *hostKeyDB) check(address string, remote net.Addr, remoteKey ssh.Public
 		// Give preference to the hostname if available.
 		host, port, err := net.SplitHostPort(address)
 		if err != nil {
-			return fmt.Errorf("knownhosts: SplitHostPort(%s): %v", address, err)
+			return fmt.Errorf("knownhosts: SplitHostPort(%s): %w", address, err)
 		}
 
 		hostToCheck = addr{host, port}
@@ -402,7 +402,7 @@ func (db *hostKeyDB) Read(r io.Reader, filename string) error {
 		}
 
 		if err := db.parseLine(line, filename, lineNum); err != nil {
-			return fmt.Errorf("knownhosts: %s:%d: %v", filename, lineNum, err)
+			return fmt.Errorf("knownhosts: %s:%d: %w", filename, lineNum, err)
 		}
 	}
 	return scanner.Err()

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -309,7 +309,7 @@ func checkSourceAddress(addr net.Addr, sourceAddrs string) error {
 		} else {
 			_, ipNet, err := net.ParseCIDR(sourceAddr)
 			if err != nil {
-				return fmt.Errorf("ssh: error parsing source-address restriction %q: %v", sourceAddr, err)
+				return fmt.Errorf("ssh: error parsing source-address restriction %q: %w", sourceAddr, err)
 			}
 
 			if ipNet.Contains(tcpAddr.IP) {

--- a/ssh/tcpip.go
+++ b/ssh/tcpip.go
@@ -81,7 +81,7 @@ func (c *Client) autoPortListenWorkaround(laddr *net.TCPAddr) (net.Listener, err
 			return sshListener, err
 		}
 	}
-	return nil, fmt.Errorf("ssh: listen on random port failed after %d tries: %v", tries, err)
+	return nil, fmt.Errorf("ssh: listen on random port failed after %d tries: %w", tries, err)
 }
 
 // RFC 4254 7.1


### PR DESCRIPTION
I wanted to be able to use error.Is to match io or syscall errors on ssh network error. 

This is currently not possible because errors are not wrapped. 

This change replace `%v` verb with `%w` in fmt.Errorf() calls.

I was looking to fix this in `ssh` package but found that it could be extended to other package. 
This change should be transparent to existing code since they can still rely on old error comparison but will provide more details in case of check with `errors.Is` or `errors.As`.

