### PR TITLE
ssh: add hmac-sha2-512

### DIFF
--- a/ssh/common.go
+++ b/ssh/common.go
@@ -85,7 +85,7 @@ var supportedHostKeyAlgos = []string{
 // This is based on RFC 4253, section 6.4, but with hmac-md5 variants removed
 // because they have reached the end of their useful life.
 var supportedMACs = []string{
-	"hmac-sha2-512-etm@openssh.com", "hmac-sha2-256-etm@openssh.com", "hmac-sha2-256", "hmac-sha1", "hmac-sha1-96",
+	"hmac-sha2-512-etm@openssh.com", "hmac-sha2-256-etm@openssh.com", "hmac-sha2-256", "hmac-sha2-512", "hmac-sha1", "hmac-sha1-96",
 }
 
 var supportedCompressions = []string{compressionNone}

--- a/ssh/mac.go
+++ b/ssh/mac.go
@@ -53,6 +53,9 @@ var macModes = map[string]*macMode{
 	"hmac-sha2-256-etm@openssh.com": {32, true, func(key []byte) hash.Hash {
 		return hmac.New(sha256.New, key)
 	}},
+	"hmac-sha2-512": {64, false, func(key []byte) hash.Hash {
+		return hmac.New(sha512.New, key)
+	}},
 	"hmac-sha2-256": {32, false, func(key []byte) hash.Hash {
 		return hmac.New(sha256.New, key)
 	}},


### PR DESCRIPTION
This adds support for hmac-sha2-512 to ensure compatibility with SSH clients that request this MAC algorithm.

This rebases https://github.com/golang/crypto/pull/18.