### PR TITLE
return acmeClient without lock when client is already initialized

### DIFF
--- a/acme/autocert/autocert.go
+++ b/acme/autocert/autocert.go
@@ -977,12 +977,11 @@ func (m *Manager) accountKey(ctx context.Context) (crypto.Signer, error) {
 }
 
 func (m *Manager) acmeClient(ctx context.Context) (*acme.Client, error) {
-	m.clientMu.Lock()
-	defer m.clientMu.Unlock()
 	if m.client != nil {
 		return m.client, nil
 	}
-
+	m.clientMu.Lock()
+	defer m.clientMu.Unlock()
 	client := m.Client
 	if client == nil {
 		client = &acme.Client{DirectoryURL: DefaultACMEDirectory}


### PR DESCRIPTION
the problem is we always lock when we calling acmeClient even when client is already initialized so this change will lock only if client in nil 