### PR TITLE
ssh: add (*Client).DialContext method

### DIFF
--- a/ssh/tcpip.go
+++ b/ssh/tcpip.go
@@ -334,9 +334,12 @@ func (l *tcpListener) Addr() net.Addr {
 }
 
 // DialContext initiates a connection to the addr from the remote host.
-// If the supplied context is cancelled before the connection can be opened,
-// ctx.Err() will be returned.
-// The resulting connection has a zero LocalAddr() and RemoteAddr().
+//
+// The provided Context must be non-nil. If the context expires before the
+// connection is complete, an error is returned. Once successfully connected,
+// any expiration of the context will not affect the connection.
+//
+// See func Dial for additional information.
 func (c *Client) DialContext(ctx context.Context, n, addr string) (net.Conn, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/ssh/tcpip_test.go
+++ b/ssh/tcpip_test.go
@@ -26,6 +26,9 @@ func TestClientImplementsDialContext(t *testing.T) {
 	type ContextDialer interface {
 		DialContext(context.Context, string, string) (net.Conn, error)
 	}
+	// Belt and suspenders assertion, since package net does not
+	// declare a ContextDialer type.
+	var _ ContextDialer = &net.Dialer{}
 	var _ ContextDialer = &Client{}
 }
 

--- a/ssh/tcpip_test.go
+++ b/ssh/tcpip_test.go
@@ -51,13 +51,3 @@ func TestClientDialContextWithDeadline(t *testing.T) {
 		t.Errorf("DialContext: got nil error, expected %v", context.DeadlineExceeded)
 	}
 }
-
-func TestClientDialContextWithTimeout(t *testing.T) {
-	c := &Client{}
-	ctx, cancel := context.WithTimeout(context.Background(), 0)
-	defer cancel()
-	_, err := c.DialContext(ctx, "tcp", "localhost:1000")
-	if err != context.DeadlineExceeded {
-		t.Errorf("DialContext: got nil error, expected %v", context.DeadlineExceeded)
-	}
-}

--- a/ssh/test/dial_unix_test.go
+++ b/ssh/test/dial_unix_test.go
@@ -10,6 +10,7 @@ package test
 // direct-tcpip and direct-streamlocal functional tests
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -47,19 +48,38 @@ func testDial(t *testing.T, n, listenAddr string, x dialTester) {
 		}
 	}()
 
-	conn, err := sshConn.Dial(n, l.Addr().String())
-	if err != nil {
-		t.Fatalf("Dial: %v", err)
+	{
+		conn, err := sshConn.Dial(n, l.Addr().String())
+		if err != nil {
+			t.Fatalf("Dial: %v", err)
+		}
+		x.TestClientConn(t, conn)
+		defer conn.Close()
+		b, err := io.ReadAll(conn)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		t.Logf("got %q", string(b))
+		if string(b) != testData {
+			t.Fatalf("expected %q, got %q", testData, string(b))
+		}
 	}
-	x.TestClientConn(t, conn)
-	defer conn.Close()
-	b, err := io.ReadAll(conn)
-	if err != nil {
-		t.Fatalf("ReadAll: %v", err)
-	}
-	t.Logf("got %q", string(b))
-	if string(b) != testData {
-		t.Fatalf("expected %q, got %q", testData, string(b))
+
+	{
+		conn, err := sshConn.DialContext(context.Background(), n, l.Addr().String())
+		if err != nil {
+			t.Fatalf("Dial: %v", err)
+		}
+		x.TestClientConn(t, conn)
+		defer conn.Close()
+		b, err := io.ReadAll(conn)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		t.Logf("got %q", string(b))
+		if string(b) != testData {
+			t.Fatalf("expected %q, got %q", testData, string(b))
+		}
 	}
 }
 


### PR DESCRIPTION
This change adds DialContext to ssh.Client, which opens a TCP-IP
connection tunneled over the SSH connection. This is useful for
proxying network connections, e.g. setting
(net/http.Transport).DialContext.

Fixes golang/go#20288.