### PR TITLE
fix TestValidTerminalMode: missing output from echo SHELL $SHELL

### DIFF
--- a/ssh/test/session_test.go
+++ b/ssh/test/session_test.go
@@ -248,7 +248,7 @@ func TestValidTerminalMode(t *testing.T) {
 		t.Fatalf("session failed: %s", err)
 	}
 
-	if _, err := io.WriteString(stdin, "echo SHELL $SHELL && stty -a && exit\n"); err != nil {
+	if _, err := io.WriteString(stdin, "echo && echo SHELL $SHELL && stty -a && exit\n"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -258,7 +258,7 @@ func TestValidTerminalMode(t *testing.T) {
 	}
 
 	if testing.Verbose() {
-		t.Logf("echo SHELL $SHELL && stty -a && exit:\n%s", buf)
+		t.Logf("echo && echo SHELL $SHELL && stty -a && exit:\n%s", buf)
 	}
 
 	shellLine := regexp.MustCompile("(?m)^SHELL (.*)$").FindStringSubmatch(buf.String())


### PR DESCRIPTION
add leading `echo` to have better compatibility 

before

```
 go test -run ^TestValidTerminalMode -v
=== RUN   TestValidTerminalMode
    session_test.go:261: echo SHELL $SHELL && stty -a && exit:
        Last login: Thu Jul  6 12:24:38 2023 from 192.168.200.1
SHELL /bin/bashubuntu:~$
        speed 38400 baud; rows 80; columns 40;
        line = 0;
        intr = ^C; quit = ^\; erase = ^?;
        kill = ^U; eof = ^D; eol = <undef>;
        eol2 = <undef>; swtch = <undef>;
        start = ^Q; stop = ^S; susp = ^Z;
        rprnt = ^R; werase = ^W; lnext = ^V;
        discard = ^O; min = 1; time = 0;
        -parenb -parodd -cmspar cs8 -hupcl
        -cstopb cread -clocal -crtscts
        -ignbrk -brkint -ignpar -parmrk -inpck
        -istrip -inlcr -igncr icrnl ixon -ixoff
        -iuclc -ixany -imaxbel -iutf8
        opost -olcuc -ocrnl onlcr -onocr -onlret
        -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0
        isig icanon iexten -echo echoe echok
        -echonl -noflsh -xcase -tostop -echoprt
        echoctl echoke -flusho -extproc
        logout
    session_test.go:266: missing output from echo SHELL $SHELL
```

after

```
 go test -run ^TestValidTerminalMode -v
=== RUN   TestValidTerminalMode
    session_test.go:261: echo SHELL $SHELL && stty -a && exit:
        Last login: Thu Jul  6 12:24:38 2023 from 192.168.200.1
        bolian@ubuntu:~$
        SHELL /bin/bash
        speed 38400 baud; rows 80; columns 40;
        line = 0;
        intr = ^C; quit = ^\; erase = ^?;
        kill = ^U; eof = ^D; eol = <undef>;
        eol2 = <undef>; swtch = <undef>;
        start = ^Q; stop = ^S; susp = ^Z;
        rprnt = ^R; werase = ^W; lnext = ^V;
        discard = ^O; min = 1; time = 0;
        -parenb -parodd -cmspar cs8 -hupcl
        -cstopb cread -clocal -crtscts
        -ignbrk -brkint -ignpar -parmrk -inpck
        -istrip -inlcr -igncr icrnl ixon -ixoff
        -iuclc -ixany -imaxbel -iutf8
        opost -olcuc -ocrnl onlcr -onocr -onlret
        -ofill -ofdel nl0 cr0 tab0 bs0 vt0 ff0
        isig icanon iexten -echo echoe echok
        -echonl -noflsh -xcase -tostop -echoprt
        echoctl echoke -flusho -extproc
        logout
--- PASS: TestValidTerminalMode (0.06s)
```