### PR TITLE
ssh/knownhosts: knownhost to support io.reader 

### DIFF
--- a/ssh/knownhosts/reader.go
+++ b/ssh/knownhosts/reader.go
@@ -1,0 +1,21 @@
+package knownhosts
+
+import (
+	"io"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func NewFromReader(r io.Reader) (ssh.HostKeyCallback, error) {
+	db := newHostKeyDB()
+	if err := db.Read(r, ""); err != nil {
+		return nil, err
+	}
+
+	var certChecker ssh.CertChecker
+	certChecker.IsHostAuthority = db.IsHostAuthority
+	certChecker.IsRevoked = db.IsRevoked
+	certChecker.HostKeyFallback = db.check
+
+	return certChecker.CheckHostKey, nil
+}

--- a/ssh/knownhosts/reader.go
+++ b/ssh/knownhosts/reader.go
@@ -12,9 +12,9 @@ import (
 // operates on the hostname if available, i.e. if a server changes its
 // IP address, the host key check will still succeed, even though a
 // record of the new IP address is not available.
-func NewFromReader(r io.Reader) (ssh.HostKeyCallback, error) {
+func NewFromReader(readers ...io.Reader) (ssh.HostKeyCallback, error) {
 	db := newHostKeyDB()
-	if err := db.Read(r, ""); err != nil {
+	if err := db.Read(io.MultiReader(readers...), ""); err != nil {
 		return nil, err
 	}
 

--- a/ssh/knownhosts/reader.go
+++ b/ssh/knownhosts/reader.go
@@ -6,6 +6,12 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// NewFromReader creates a host key callback from the given OpenSSH host io.Reader
+// which is in SSH_KNOWN_HOSTS_FILE_FORMAT. The returned callback is for use in
+// ssh.ClientConfig.HostKeyCallback. By preference, the key check
+// operates on the hostname if available, i.e. if a server changes its
+// IP address, the host key check will still succeed, even though a
+// record of the new IP address is not available.
 func NewFromReader(r io.Reader) (ssh.HostKeyCallback, error) {
 	db := newHostKeyDB()
 	if err := db.Read(r, ""); err != nil {

--- a/ssh/knownhosts/reader_test.go
+++ b/ssh/knownhosts/reader_test.go
@@ -1,0 +1,17 @@
+package knownhosts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestNewFromReader(t *testing.T) {
+	str := fmt.Sprintf("server*.domain %s", edKeyStr)
+
+	_, err := NewFromReader(strings.NewReader(str))
+	if err != nil {
+		t.Fatalf("cannot read from string: %v", err)
+	}
+
+}


### PR DESCRIPTION
add `NewFromReader(reader ...io.Reader) (ssh.HostKeyCallback, error)` to knownhosts

fixed [#62656](https://github.com/golang/go/issues/62656)