### PR TITLE
CVE-2023-44487 - bump golang.org/x/net to v0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module golang.org/x/crypto
 go 1.18
 
 require (
-	golang.org/x/net v0.10.0 // tagx:ignore
+	golang.org/x/net v0.17.0 // tagx:ignore
 	golang.org/x/sys v0.13.0
 	golang.org/x/term v0.13.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
-golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=


### PR DESCRIPTION
fixes CVE-2023-44487