### PR TITLE
shake: add validity check

### DIFF
--- a/sha3/shake.go
+++ b/sha3/shake.go
@@ -82,8 +82,8 @@ func leftEncode(value uint64) []byte {
 }
 
 func newCShake(N, S []byte, rate, outputLen int, dsbyte byte) (ShakeHash, error) {
-	if len(N) >= 255 || len(S) >= 255 {
-		return nil, errors.New("crypto/cSHAKE: N and S should less than 255 bytes")
+	if len(N) >= 256 || len(S) >= 256 {
+		return nil, errors.New("crypto/cSHAKE: N and S can be at most 255 bytes long")
 	}
 
 	c := cshakeState{state: &state{rate: rate, outputLen: outputLen, dsbyte: dsbyte}}

--- a/sha3/shake.go
+++ b/sha3/shake.go
@@ -82,8 +82,8 @@ func leftEncode(value uint64) []byte {
 }
 
 func newCShake(N, S []byte, rate, outputLen int, dsbyte byte) (ShakeHash, error) {
-	if len(N) >= 256 || len(S) >= 256 {
-		return nil, errors.New("crypto/cSHAKE: N and S can be at most 255 bytes long")
+	if len(N) >= 255 || len(S) >= 255 {
+		return nil, errors.New("crypto/cSHAKE: N and S should less than 255 bytes")
 	}
 
 	c := cshakeState{state: &state{rate: rate, outputLen: outputLen, dsbyte: dsbyte}}


### PR DESCRIPTION
follow “cSHAKE implementations is based on NIST SP 800-185 [2]” 3.3 Definition

I think we should check the length validity, len(N) and len(S) should less than 2040bit(255 byte)

- refactor 'constructor' return type to '(ShakeHash, error)'
- modify some function call to invoke consistently 
- add a basic length check when create newCShake
- add test for invalid length message use

fix [#66232](https://github.com/golang/go/issues/66232)