### PR TITLE
perf: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/ssh/agent/keyring.go
+++ b/ssh/agent/keyring.go
@@ -103,7 +103,7 @@ func (r *keyring) Unlock(passphrase []byte) error {
 		return errors.New("agent: not locked")
 	}
 	if 1 != subtle.ConstantTimeCompare(passphrase, r.passphrase) {
-		return fmt.Errorf("agent: incorrect passphrase")
+		return errors.New("agent: incorrect passphrase")
 	}
 
 	r.locked = false


### PR DESCRIPTION
If you don‘’t need to format the string, it is recommended to use error.New()