### PR TITLE
sha3: fix compatibility with go1.18

### DIFF
--- a/sha3/xor.go
+++ b/sha3/xor.go
@@ -5,7 +5,6 @@
 package sha3
 
 import (
-	"crypto/subtle"
 	"encoding/binary"
 	"unsafe"
 
@@ -22,7 +21,7 @@ func xorIn(d *state, buf []byte) {
 		}
 	} else {
 		ab := (*[25 * 64 / 8]byte)(unsafe.Pointer(&d.a))
-		subtle.XORBytes(ab[:], ab[:], buf)
+		xorBytes(ab[:], ab[:], buf)
 	}
 }
 

--- a/sha3/xor_compat.go
+++ b/sha3/xor_compat.go
@@ -1,0 +1,13 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.19
+
+package sha3
+
+import _ "unsafe" // for go:linkname
+
+//go:linkname xorBytes crypto/cipher.xorBytes
+//go:noescape
+func xorBytes(dst, a, b []byte)

--- a/sha3/xor_go119.go
+++ b/sha3/xor_go119.go
@@ -1,0 +1,11 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.19
+
+package sha3
+
+import "crypto/subtle"
+
+var xorBytes = subtle.XORBytes


### PR DESCRIPTION
Fix https://github.com/golang/go/issues/68147

I'm not familiar with the relevant code, maybe there is a better solution for it.