### PR TITLE
bcrypt: update InvalidCostError message to describe cost range inclusive

### DIFF
--- a/bcrypt/bcrypt.go
+++ b/bcrypt/bcrypt.go
@@ -50,7 +50,7 @@ func (ih InvalidHashPrefixError) Error() string {
 type InvalidCostError int
 
 func (ic InvalidCostError) Error() string {
-	return fmt.Sprintf("crypto/bcrypt: cost %d is outside allowed range (%d,%d)", int(ic), MinCost, MaxCost)
+	return fmt.Sprintf("crypto/bcrypt: cost %d is outside allowed range [%d,%d]", int(ic), MinCost, MaxCost)
 }
 
 const (


### PR DESCRIPTION
Updates `InvalidCostError` error string in the `bcrypt` package to present cost range bounds as inclusive (brackets []) instead of exclusive (parentheses ()).