### PR TITLE
all: rewrite interface{} to any

### DIFF
--- a/acme/acme_test.go
+++ b/acme/acme_test.go
@@ -39,7 +39,7 @@ func newTestClient() *Client {
 
 // Decodes a JWS-encoded request and unmarshals the decoded JSON into a provided
 // interface.
-func decodeJWSRequest(t *testing.T, v interface{}, r io.Reader) {
+func decodeJWSRequest(t *testing.T, v any, r io.Reader) {
 	// Decode request
 	var req struct{ Payload string }
 	if err := json.NewDecoder(r).Decode(&req); err != nil {

--- a/acme/autocert/autocert_test.go
+++ b/acme/autocert/autocert_test.go
@@ -112,11 +112,11 @@ func (m *memCache) numCerts() int {
 	return res
 }
 
-func dummyCert(pub interface{}, san ...string) ([]byte, error) {
+func dummyCert(pub any, san ...string) ([]byte, error) {
 	return dateDummyCert(pub, time.Now(), time.Now().Add(90*24*time.Hour), san...)
 }
 
-func dateDummyCert(pub interface{}, start, end time.Time, san ...string) ([]byte, error) {
+func dateDummyCert(pub any, start, end time.Time, san ...string) ([]byte, error) {
 	// use EC key to run faster on 386
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/acme/autocert/internal/acmetest/ca.go
+++ b/acme/autocert/internal/acmetest/ca.go
@@ -174,7 +174,7 @@ func (ca *CAServer) Start() *CAServer {
 	return ca
 }
 
-func (ca *CAServer) serverURL(format string, arg ...interface{}) string {
+func (ca *CAServer) serverURL(format string, arg ...any) string {
 	return ca.server.URL + fmt.Sprintf(format, arg...)
 }
 
@@ -199,7 +199,7 @@ func (ca *CAServer) getHandler(domain string) (http.Handler, bool) {
 	return h, ok
 }
 
-func (ca *CAServer) httpErrorf(w http.ResponseWriter, code int, format string, a ...interface{}) {
+func (ca *CAServer) httpErrorf(w http.ResponseWriter, code int, format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
 	ca.t.Errorf(format, a...)
 	http.Error(w, s, code)
@@ -767,7 +767,7 @@ func (ca *CAServer) verifyHTTPChallenge(a *authorization) error {
 	return nil
 }
 
-func decodePayload(v interface{}, r io.Reader) error {
+func decodePayload(v any, r io.Reader) error {
 	var req struct{ Payload string }
 	if err := json.NewDecoder(r).Decode(&req); err != nil {
 		return err

--- a/acme/http.go
+++ b/acme/http.go
@@ -172,7 +172,7 @@ func (c *Client) postAsGet(ctx context.Context, url string, ok resOkay) (*http.R
 // post retries unsuccessful attempts according to c.RetryBackoff
 // until the context is done or a non-retriable error is received.
 // It uses postNoRetry to make individual requests.
-func (c *Client) post(ctx context.Context, key crypto.Signer, url string, body interface{}, ok resOkay) (*http.Response, error) {
+func (c *Client) post(ctx context.Context, key crypto.Signer, url string, body any, ok resOkay) (*http.Response, error) {
 	retry := c.retryTimer()
 	for {
 		res, req, err := c.postNoRetry(ctx, key, url, body)
@@ -214,7 +214,7 @@ func (c *Client) post(ctx context.Context, key crypto.Signer, url string, body i
 // and JWK is used only when KID is unavailable: new account endpoint and certificate
 // revocation requests authenticated by a cert key.
 // See jwsEncodeJSON for other details.
-func (c *Client) postNoRetry(ctx context.Context, key crypto.Signer, url string, body interface{}) (*http.Response, *http.Request, error) {
+func (c *Client) postNoRetry(ctx context.Context, key crypto.Signer, url string, body any) (*http.Response, *http.Request, error) {
 	kid := noKeyID
 	if key == nil {
 		if c.Key == nil {

--- a/acme/internal/acmeprobe/prober.go
+++ b/acme/internal/acmeprobe/prober.go
@@ -143,7 +143,7 @@ type prober struct {
 	errors []error
 }
 
-func (p *prober) errorf(format string, a ...interface{}) {
+func (p *prober) errorf(format string, a ...any) {
 	err := fmt.Errorf(format, a...)
 	log.Print(err)
 	p.errors = append(p.errors, err)

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -59,7 +59,7 @@ type jsonWebSignature struct {
 // If nonce is non-empty, its quoted value is inserted in the protected header.
 //
 // See https://tools.ietf.org/html/rfc7515#section-7.
-func jwsEncodeJSON(claimset interface{}, key crypto.Signer, kid KeyID, nonce, url string) ([]byte, error) {
+func jwsEncodeJSON(claimset any, key crypto.Signer, kid KeyID, nonce, url string) ([]byte, error) {
 	if key == nil {
 		return nil, errors.New("nil key")
 	}

--- a/cryptobyte/asn1.go
+++ b/cryptobyte/asn1.go
@@ -208,7 +208,7 @@ func (b *Builder) AddASN1NULL() {
 
 // MarshalASN1 calls encoding_asn1.Marshal on its input and appends the result if
 // successful or records an error if one occurred.
-func (b *Builder) MarshalASN1(v interface{}) {
+func (b *Builder) MarshalASN1(v any) {
 	// NOTE(martinkr): This is somewhat of a hack to allow propagation of
 	// encoding_asn1.Marshal errors into Builder.err. N.B. if you call MarshalASN1 with a
 	// value embedded into a struct, its tag information is lost.
@@ -270,7 +270,7 @@ func (s *String) ReadASN1Boolean(out *bool) bool {
 // big-endian binary values that share memory with s. Positive values will have
 // no leading zeroes, and zero will be returned as a single zero byte.
 // ReadASN1Integer reports whether the read was successful.
-func (s *String) ReadASN1Integer(out interface{}) bool {
+func (s *String) ReadASN1Integer(out any) bool {
 	switch out := out.(type) {
 	case *int, *int8, *int16, *int32, *int64:
 		var i int64
@@ -680,7 +680,7 @@ func (s *String) SkipOptionalASN1(tag asn1.Tag) bool {
 // tagged with tag into out and advances. If no element with a matching tag is
 // present, it writes defaultValue into out instead. Otherwise, it behaves like
 // ReadASN1Integer.
-func (s *String) ReadOptionalASN1Integer(out interface{}, tag asn1.Tag, defaultValue interface{}) bool {
+func (s *String) ReadOptionalASN1Integer(out any, tag asn1.Tag, defaultValue any) bool {
 	var present bool
 	var i String
 	if !s.ReadOptionalASN1(&i, &present, tag) {

--- a/cryptobyte/asn1_test.go
+++ b/cryptobyte/asn1_test.go
@@ -20,7 +20,7 @@ type readASN1Test struct {
 	in   []byte
 	tag  asn1.Tag
 	ok   bool
-	out  interface{}
+	out  any
 }
 
 var readASN1TestData = []readASN1Test{

--- a/internal/wycheproof/aead_test.go
+++ b/internal/wycheproof/aead_test.go
@@ -65,7 +65,7 @@ func TestAEAD(t *testing.T) {
 		// the expected size of the tag in bits
 		TagSize int               `json:"tagSize,omitempty"`
 		Tests   []*AeadTestVector `json:"tests,omitempty"`
-		Type    interface{}       `json:"type,omitempty"`
+		Type    any               `json:"type,omitempty"`
 	}
 
 	// Root
@@ -85,7 +85,7 @@ func TestAEAD(t *testing.T) {
 
 		// the number of test vectors in this test
 		NumberOfTests int              `json:"numberOfTests,omitempty"`
-		Schema        interface{}      `json:"schema,omitempty"`
+		Schema        any              `json:"schema,omitempty"`
 		TestGroups    []*AeadTestGroup `json:"testGroups,omitempty"`
 	}
 

--- a/internal/wycheproof/aes_cbc_test.go
+++ b/internal/wycheproof/aes_cbc_test.go
@@ -57,7 +57,7 @@ func TestAesCbc(t *testing.T) {
 		// the expected size of the tag in bits
 		TagSize int                 `json:"tagSize,omitempty"`
 		Tests   []*IndCpaTestVector `json:"tests,omitempty"`
-		Type    interface{}         `json:"type,omitempty"`
+		Type    any                 `json:"type,omitempty"`
 	}
 
 	// Root
@@ -77,7 +77,7 @@ func TestAesCbc(t *testing.T) {
 
 		// the number of test vectors in this test
 		NumberOfTests int                `json:"numberOfTests,omitempty"`
-		Schema        interface{}        `json:"schema,omitempty"`
+		Schema        any                `json:"schema,omitempty"`
 		TestGroups    []*IndCpaTestGroup `json:"testGroups,omitempty"`
 	}
 

--- a/internal/wycheproof/dsa_test.go
+++ b/internal/wycheproof/dsa_test.go
@@ -71,7 +71,7 @@ func TestDsa(t *testing.T) {
 		// the hash function used for DSA
 		Sha   string                    `json:"sha,omitempty"`
 		Tests []*AsnSignatureTestVector `json:"tests,omitempty"`
-		Type  interface{}               `json:"type,omitempty"`
+		Type  any                       `json:"type,omitempty"`
 	}
 
 	// Notes a description of the labels used in the test vectors
@@ -95,7 +95,7 @@ func TestDsa(t *testing.T) {
 
 		// the number of test vectors in this test
 		NumberOfTests int             `json:"numberOfTests,omitempty"`
-		Schema        interface{}     `json:"schema,omitempty"`
+		Schema        any             `json:"schema,omitempty"`
 		TestGroups    []*DsaTestGroup `json:"testGroups,omitempty"`
 	}
 

--- a/internal/wycheproof/ecdh_test.go
+++ b/internal/wycheproof/ecdh_test.go
@@ -108,7 +108,7 @@ func TestECDH(t *testing.T) {
 	}
 }
 
-func decodeCompressedPKIX(der []byte) (interface{}, error) {
+func decodeCompressedPKIX(der []byte) (any, error) {
 	s := cryptobyte.String(der)
 	var s1, s2 cryptobyte.String
 	var algoOID, namedCurveOID asn1.ObjectIdentifier

--- a/internal/wycheproof/ecdsa_test.go
+++ b/internal/wycheproof/ecdsa_test.go
@@ -31,7 +31,7 @@ func TestECDSA(t *testing.T) {
 
 	type ECPublicKey struct {
 		// The EC group used by this public key
-		Curve interface{} `json:"curve"`
+		Curve any `json:"curve"`
 	}
 
 	type ECDSATestGroup struct {

--- a/internal/wycheproof/eddsa_test.go
+++ b/internal/wycheproof/eddsa_test.go
@@ -59,7 +59,7 @@ func TestEddsa(t *testing.T) {
 		// Pem encoded public key
 		KeyPem string                 `json:"keyPem,omitempty"`
 		Tests  []*SignatureTestVector `json:"tests,omitempty"`
-		Type   interface{}            `json:"type,omitempty"`
+		Type   any                    `json:"type,omitempty"`
 	}
 
 	// Root
@@ -79,7 +79,7 @@ func TestEddsa(t *testing.T) {
 
 		// the number of test vectors in this test
 		NumberOfTests int               `json:"numberOfTests,omitempty"`
-		Schema        interface{}       `json:"schema,omitempty"`
+		Schema        any               `json:"schema,omitempty"`
 		TestGroups    []*EddsaTestGroup `json:"testGroups,omitempty"`
 	}
 

--- a/internal/wycheproof/hkdf_test.go
+++ b/internal/wycheproof/hkdf_test.go
@@ -55,7 +55,7 @@ func TestHkdf(t *testing.T) {
 		// the size of the ikm in bits
 		KeySize int               `json:"keySize,omitempty"`
 		Tests   []*HkdfTestVector `json:"tests,omitempty"`
-		Type    interface{}       `json:"type,omitempty"`
+		Type    any               `json:"type,omitempty"`
 	}
 
 	// Root
@@ -75,7 +75,7 @@ func TestHkdf(t *testing.T) {
 
 		// the number of test vectors in this test
 		NumberOfTests int              `json:"numberOfTests,omitempty"`
-		Schema        interface{}      `json:"schema,omitempty"`
+		Schema        any              `json:"schema,omitempty"`
 		TestGroups    []*HkdfTestGroup `json:"testGroups,omitempty"`
 	}
 

--- a/internal/wycheproof/hmac_test.go
+++ b/internal/wycheproof/hmac_test.go
@@ -44,7 +44,7 @@ func TestHMAC(t *testing.T) {
 		// the expected size of the tag in bits
 		TagSize int              `json:"tagSize,omitempty"`
 		Tests   []*MacTestVector `json:"tests,omitempty"`
-		Type    interface{}      `json:"type,omitempty"`
+		Type    any              `json:"type,omitempty"`
 	}
 
 	// Notes a description of the labels used in the test vectors
@@ -68,7 +68,7 @@ func TestHMAC(t *testing.T) {
 
 		// the number of test vectors in this test
 		NumberOfTests int             `json:"numberOfTests,omitempty"`
-		Schema        interface{}     `json:"schema,omitempty"`
+		Schema        any             `json:"schema,omitempty"`
 		TestGroups    []*MacTestGroup `json:"testGroups,omitempty"`
 	}
 

--- a/internal/wycheproof/rsa_oaep_decrypt_test.go
+++ b/internal/wycheproof/rsa_oaep_decrypt_test.go
@@ -69,7 +69,7 @@ func TestRSAOAEPDecrypt(t *testing.T) {
 		// The hash function for hashing the label.
 		Sha   string                 `json:"sha,omitempty"`
 		Tests []*RsaesOaepTestVector `json:"tests,omitempty"`
-		Type  interface{}            `json:"type,omitempty"`
+		Type  any                    `json:"type,omitempty"`
 	}
 
 	// Root
@@ -89,7 +89,7 @@ func TestRSAOAEPDecrypt(t *testing.T) {
 
 		// the number of test vectors in this test
 		NumberOfTests int                   `json:"numberOfTests,omitempty"`
-		Schema        interface{}           `json:"schema,omitempty"`
+		Schema        any                   `json:"schema,omitempty"`
 		TestGroups    []*RsaesOaepTestGroup `json:"testGroups,omitempty"`
 	}
 

--- a/internal/wycheproof/rsa_pss_test.go
+++ b/internal/wycheproof/rsa_pss_test.go
@@ -73,7 +73,7 @@ func TestRsaPss(t *testing.T) {
 		// the hash function used for the message
 		Sha   string                 `json:"sha,omitempty"`
 		Tests []*SignatureTestVector `json:"tests,omitempty"`
-		Type  interface{}            `json:"type,omitempty"`
+		Type  any                    `json:"type,omitempty"`
 	}
 
 	// Root
@@ -93,7 +93,7 @@ func TestRsaPss(t *testing.T) {
 
 		// the number of test vectors in this test
 		NumberOfTests int                     `json:"numberOfTests,omitempty"`
-		Schema        interface{}             `json:"schema,omitempty"`
+		Schema        any                     `json:"schema,omitempty"`
 		TestGroups    []*RsassaPkcs1TestGroup `json:"testGroups,omitempty"`
 	}
 

--- a/internal/wycheproof/rsa_signature_test.go
+++ b/internal/wycheproof/rsa_signature_test.go
@@ -70,7 +70,7 @@ func TestRsa(t *testing.T) {
 		// the hash function used for the message
 		Sha   string                 `json:"sha,omitempty"`
 		Tests []*SignatureTestVector `json:"tests,omitempty"`
-		Type  interface{}            `json:"type,omitempty"`
+		Type  any                    `json:"type,omitempty"`
 	}
 
 	// Root
@@ -90,7 +90,7 @@ func TestRsa(t *testing.T) {
 
 		// the number of test vectors in this test
 		NumberOfTests int                     `json:"numberOfTests,omitempty"`
-		Schema        interface{}             `json:"schema,omitempty"`
+		Schema        any                     `json:"schema,omitempty"`
 		TestGroups    []*RsassaPkcs1TestGroup `json:"testGroups,omitempty"`
 	}
 

--- a/internal/wycheproof/wycheproof_test.go
+++ b/internal/wycheproof/wycheproof_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func readTestVector(t *testing.T, f string, dest interface{}) {
+func readTestVector(t *testing.T, f string, dest any) {
 	b, err := os.ReadFile(filepath.Join(wycheproofTestVectorsDir, f))
 	if err != nil {
 		t.Fatalf("failed to read json file: %v", err)
@@ -82,7 +82,7 @@ func decodeHex(s string) []byte {
 	return b
 }
 
-func decodePublicKey(der string) interface{} {
+func decodePublicKey(der string) any {
 	d := decodeHex(der)
 	pub, err := x509.ParsePKIXPublicKey(d)
 	if err != nil {

--- a/ocsp/ocsp.go
+++ b/ocsp/ocsp.go
@@ -182,7 +182,7 @@ var signatureAlgorithmDetails = []struct {
 }
 
 // TODO(rlb): This is also from crypto/x509, so same comment as AGL's below
-func signingParamsForPublicKey(pub interface{}, requestedSigAlgo x509.SignatureAlgorithm) (hashFunc crypto.Hash, sigAlgo pkix.AlgorithmIdentifier, err error) {
+func signingParamsForPublicKey(pub any, requestedSigAlgo x509.SignatureAlgorithm) (hashFunc crypto.Hash, sigAlgo pkix.AlgorithmIdentifier, err error) {
 	var pubType x509.PublicKeyAlgorithm
 
 	switch pub := pub.(type) {

--- a/openpgp/packet/private_key.go
+++ b/openpgp/packet/private_key.go
@@ -30,7 +30,7 @@ type PrivateKey struct {
 	encryptedData []byte
 	cipher        CipherFunction
 	s2k           func(out, in []byte)
-	PrivateKey    interface{} // An *{rsa|dsa|ecdsa}.PrivateKey or crypto.Signer/crypto.Decrypter (Decryptor RSA only).
+	PrivateKey    any // An *{rsa|dsa|ecdsa}.PrivateKey or crypto.Signer/crypto.Decrypter (Decryptor RSA only).
 	sha1Checksum  bool
 	iv            []byte
 }

--- a/openpgp/packet/public_key.go
+++ b/openpgp/packet/public_key.go
@@ -153,7 +153,7 @@ func (f *ecdhKdf) byteLen() int {
 type PublicKey struct {
 	CreationTime time.Time
 	PubKeyAlgo   PublicKeyAlgorithm
-	PublicKey    interface{} // *rsa.PublicKey, *dsa.PublicKey or *ecdsa.PublicKey
+	PublicKey    any // *rsa.PublicKey, *dsa.PublicKey or *ecdsa.PublicKey
 	Fingerprint  [20]byte
 	KeyId        uint64
 	IsSubkey     bool

--- a/pkcs12/pkcs12.go
+++ b/pkcs12/pkcs12.go
@@ -94,7 +94,7 @@ const (
 
 // unmarshal calls asn1.Unmarshal, but also returns an error if there is any
 // trailing data after unmarshaling.
-func unmarshal(in []byte, out interface{}) error {
+func unmarshal(in []byte, out any) error {
 	trailing, err := asn1.Unmarshal(in, out)
 	if err != nil {
 		return err
@@ -222,7 +222,7 @@ func convertAttribute(attribute *pkcs12Attribute) (key, value string, err error)
 // Decode extracts a certificate and private key from pfxData. This function
 // assumes that there is only one certificate and only one private key in the
 // pfxData; if there are more use ToPEM instead.
-func Decode(pfxData []byte, password string) (privateKey interface{}, certificate *x509.Certificate, err error) {
+func Decode(pfxData []byte, password string) (privateKey any, certificate *x509.Certificate, err error) {
 	encodedPassword, err := bmpString(password)
 	if err != nil {
 		return nil, nil, err

--- a/pkcs12/safebags.go
+++ b/pkcs12/safebags.go
@@ -22,7 +22,7 @@ type certBag struct {
 	Data []byte `asn1:"tag:0,explicit"`
 }
 
-func decodePkcs8ShroudedKeyBag(asn1Data, password []byte) (privateKey interface{}, err error) {
+func decodePkcs8ShroudedKeyBag(asn1Data, password []byte) (privateKey any, err error) {
 	pkinfo := new(encryptedPrivateKeyInfo)
 	if err = unmarshal(asn1Data, pkinfo); err != nil {
 		return nil, errors.New("pkcs12: error decoding PKCS#8 shrouded key bag: " + err.Error())

--- a/ssh/agent/client.go
+++ b/ssh/agent/client.go
@@ -105,7 +105,7 @@ type AddedKey struct {
 	// PrivateKey must be a *rsa.PrivateKey, *dsa.PrivateKey,
 	// ed25519.PrivateKey or *ecdsa.PrivateKey, which will be inserted into the
 	// agent.
-	PrivateKey interface{}
+	PrivateKey any
 	// Certificate, if not nil, is communicated to the agent and will be
 	// stored with the key.
 	Certificate *ssh.Certificate
@@ -324,7 +324,7 @@ func NewClient(rw io.ReadWriter) ExtendedAgent {
 // call sends an RPC to the agent. On success, the reply is
 // unmarshaled into reply and replyType is set to the first byte of
 // the reply, which contains the type of the message.
-func (c *client) call(req []byte) (reply interface{}, err error) {
+func (c *client) call(req []byte) (reply any, err error) {
 	buf, err := c.callRaw(req)
 	if err != nil {
 		return nil, err
@@ -468,11 +468,11 @@ func (c *client) SignWithFlags(key ssh.PublicKey, data []byte, flags SignatureFl
 
 // unmarshal parses an agent message in packet, returning the parsed
 // form and the message type of packet.
-func unmarshal(packet []byte) (interface{}, error) {
+func unmarshal(packet []byte) (any, error) {
 	if len(packet) < 1 {
 		return nil, errors.New("agent: empty packet")
 	}
-	var msg interface{}
+	var msg any
 	switch packet[0] {
 	case agentFailure:
 		return new(failureAgentMsg), nil
@@ -534,7 +534,7 @@ type ed25519KeyMsg struct {
 }
 
 // Insert adds a private key to the agent.
-func (c *client) insertKey(s interface{}, comment string, constraints []byte) error {
+func (c *client) insertKey(s any, comment string, constraints []byte) error {
 	var req []byte
 	switch k := s.(type) {
 	case *rsa.PrivateKey:
@@ -668,7 +668,7 @@ func (c *client) Add(key AddedKey) error {
 	return c.insertCert(key.PrivateKey, cert, key.Comment, constraints)
 }
 
-func (c *client) insertCert(s interface{}, cert *ssh.Certificate, comment string, constraints []byte) error {
+func (c *client) insertCert(s any, cert *ssh.Certificate, comment string, constraints []byte) error {
 	var req []byte
 	switch k := s.(type) {
 	case *rsa.PrivateKey:

--- a/ssh/agent/client_test.go
+++ b/ssh/agent/client_test.go
@@ -105,21 +105,21 @@ func startKeyringAgent(t *testing.T) (client ExtendedAgent, cleanup func()) {
 	return startAgent(t, NewKeyring())
 }
 
-func testOpenSSHAgent(t *testing.T, key interface{}, cert *ssh.Certificate, lifetimeSecs uint32) {
+func testOpenSSHAgent(t *testing.T, key any, cert *ssh.Certificate, lifetimeSecs uint32) {
 	agent, _, cleanup := startOpenSSHAgent(t)
 	defer cleanup()
 
 	testAgentInterface(t, agent, key, cert, lifetimeSecs)
 }
 
-func testKeyringAgent(t *testing.T, key interface{}, cert *ssh.Certificate, lifetimeSecs uint32) {
+func testKeyringAgent(t *testing.T, key any, cert *ssh.Certificate, lifetimeSecs uint32) {
 	agent, cleanup := startKeyringAgent(t)
 	defer cleanup()
 
 	testAgentInterface(t, agent, key, cert, lifetimeSecs)
 }
 
-func testAgentInterface(t *testing.T, agent ExtendedAgent, key interface{}, cert *ssh.Certificate, lifetimeSecs uint32) {
+func testAgentInterface(t *testing.T, agent ExtendedAgent, key any, cert *ssh.Certificate, lifetimeSecs uint32) {
 	signer, err := ssh.NewSignerFromKey(key)
 	if err != nil {
 		t.Fatalf("NewSignerFromKey(%T): %v", key, err)

--- a/ssh/agent/server.go
+++ b/ssh/agent/server.go
@@ -73,7 +73,7 @@ type agentUnlockMsg struct {
 	Passphrase []byte `sshtype:"23"`
 }
 
-func (s *server) processRequest(data []byte) (interface{}, error) {
+func (s *server) processRequest(data []byte) (any, error) {
 	switch data[0] {
 	case agentRequestV1Identities:
 		return &agentV1IdentityMsg{0}, nil

--- a/ssh/agent/testdata_test.go
+++ b/ssh/agent/testdata_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	testPrivateKeys map[string]interface{}
+	testPrivateKeys map[string]any
 	testSigners     map[string]ssh.Signer
 	testPublicKeys  map[string]ssh.PublicKey
 )
@@ -26,7 +26,7 @@ func init() {
 	var err error
 
 	n := len(testdata.PEMBytes)
-	testPrivateKeys = make(map[string]interface{}, n)
+	testPrivateKeys = make(map[string]any, n)
 	testSigners = make(map[string]ssh.Signer, n)
 	testPublicKeys = make(map[string]ssh.PublicKey, n)
 	for t, k := range testdata.PEMBytes {

--- a/ssh/channel.go
+++ b/ssh/channel.go
@@ -171,7 +171,7 @@ type channel struct {
 	direction channelDirection
 
 	// Pending internal channel messages.
-	msg chan interface{}
+	msg chan any
 
 	// Since requests have no ID, there can be only one request
 	// with WantReply=true outstanding.  This lock is held by a
@@ -219,7 +219,7 @@ func (ch *channel) writePacket(packet []byte) error {
 	return err
 }
 
-func (ch *channel) sendMessage(msg interface{}) error {
+func (ch *channel) sendMessage(msg any) error {
 	if debugMux {
 		log.Printf("send(%d): %#v", ch.mux.chanList.offset, msg)
 	}
@@ -474,7 +474,7 @@ func (m *mux) newChannel(chanType string, direction channelDirection, extraData 
 		extPending:       newBuffer(),
 		direction:        direction,
 		incomingRequests: make(chan *Request, chanSize),
-		msg:              make(chan interface{}, chanSize),
+		msg:              make(chan any, chanSize),
 		chanType:         chanType,
 		extraData:        extraData,
 		mux:              m,
@@ -623,7 +623,7 @@ func (ch *channel) ackRequest(ok bool) error {
 		return errUndecided
 	}
 
-	var msg interface{}
+	var msg any
 	if !ok {
 		msg = channelRequestFailureMsg{
 			PeersID: ch.remoteId,

--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -1054,7 +1054,7 @@ func (k *skEd25519PublicKey) CryptoPublicKey() crypto.PublicKey {
 // *ecdsa.PrivateKey or any other crypto.Signer and returns a
 // corresponding Signer instance. ECDSA keys must use P-256, P-384 or
 // P-521. DSA keys must use parameter size L1024N160.
-func NewSignerFromKey(key interface{}) (Signer, error) {
+func NewSignerFromKey(key any) (Signer, error) {
 	switch key := key.(type) {
 	case crypto.Signer:
 		return NewSignerFromSigner(key)
@@ -1162,7 +1162,7 @@ func (s *wrappedSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm
 // NewPublicKey takes an *rsa.PublicKey, *dsa.PublicKey, *ecdsa.PublicKey,
 // or ed25519.PublicKey returns a corresponding PublicKey instance.
 // ECDSA keys must use P-256, P-384 or P-521.
-func NewPublicKey(key interface{}) (PublicKey, error) {
+func NewPublicKey(key any) (PublicKey, error) {
 	switch key := key.(type) {
 	case *rsa.PublicKey:
 		return (*rsaPublicKey)(key), nil
@@ -1230,7 +1230,7 @@ func (*PassphraseMissingError) Error() string {
 // ParseRawPrivateKey returns a private key from a PEM encoded private key. It supports
 // RSA, DSA, ECDSA, and Ed25519 private keys in PKCS#1, PKCS#8, OpenSSL, and OpenSSH
 // formats. If the private key is encrypted, it will return a PassphraseMissingError.
-func ParseRawPrivateKey(pemBytes []byte) (interface{}, error) {
+func ParseRawPrivateKey(pemBytes []byte) (any, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
 		return nil, errors.New("ssh: no key found")
@@ -1260,7 +1260,7 @@ func ParseRawPrivateKey(pemBytes []byte) (interface{}, error) {
 // ParseRawPrivateKeyWithPassphrase returns a private key decrypted with
 // passphrase from a PEM encoded private key. If the passphrase is wrong, it
 // will return x509.IncorrectPasswordError.
-func ParseRawPrivateKeyWithPassphrase(pemBytes, passphrase []byte) (interface{}, error) {
+func ParseRawPrivateKeyWithPassphrase(pemBytes, passphrase []byte) (any, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
 		return nil, errors.New("ssh: no key found")
@@ -1282,7 +1282,7 @@ func ParseRawPrivateKeyWithPassphrase(pemBytes, passphrase []byte) (interface{},
 		return nil, fmt.Errorf("ssh: cannot decode encrypted private keys: %v", err)
 	}
 
-	var result interface{}
+	var result any
 
 	switch block.Type {
 	case "RSA PRIVATE KEY":

--- a/ssh/keys_test.go
+++ b/ssh/keys_test.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/crypto/ssh/testdata"
 )
 
-func rawKey(pub PublicKey) interface{} {
+func rawKey(pub PublicKey) any {
 	switch k := pub.(type) {
 	case *rsaPublicKey:
 		return (*rsa.PublicKey)(k)

--- a/ssh/messages.go
+++ b/ssh/messages.go
@@ -393,7 +393,7 @@ var errShortRead = errors.New("ssh: short read")
 // in decimal, the packet must start with one of those numbers. In
 // case of error, Unmarshal returns a ParseError or
 // UnexpectedMessageError.
-func Unmarshal(data []byte, out interface{}) error {
+func Unmarshal(data []byte, out any) error {
 	v := reflect.ValueOf(out).Elem()
 	structType := v.Type()
 	expectedTypes := typeTags(structType)
@@ -516,12 +516,12 @@ func Unmarshal(data []byte, out interface{}) error {
 // member has the "sshtype" tag set to a number in decimal, that
 // number is prepended to the result. If the last of member has the
 // "ssh" tag set to "rest", its contents are appended to the output.
-func Marshal(msg interface{}) []byte {
+func Marshal(msg any) []byte {
 	out := make([]byte, 0, 64)
 	return marshalStruct(out, msg)
 }
 
-func marshalStruct(out []byte, msg interface{}) []byte {
+func marshalStruct(out []byte, msg any) []byte {
 	v := reflect.Indirect(reflect.ValueOf(msg))
 	msgTypes := typeTags(v.Type())
 	if len(msgTypes) > 0 {
@@ -795,8 +795,8 @@ func marshalString(to []byte, s []byte) []byte {
 var bigIntType = reflect.TypeOf((*big.Int)(nil))
 
 // Decode a packet into its corresponding message.
-func decode(packet []byte) (interface{}, error) {
-	var msg interface{}
+func decode(packet []byte) (any, error) {
+	var msg any
 	switch packet[0] {
 	case msgDisconnect:
 		msg = new(disconnectMsg)

--- a/ssh/mux.go
+++ b/ssh/mux.go
@@ -92,7 +92,7 @@ type mux struct {
 	incomingChannels chan NewChannel
 
 	globalSentMu     sync.Mutex
-	globalResponses  chan interface{}
+	globalResponses  chan any
 	incomingRequests chan *Request
 
 	errCond *sync.Cond
@@ -117,7 +117,7 @@ func newMux(p packetConn) *mux {
 	m := &mux{
 		conn:             p,
 		incomingChannels: make(chan NewChannel, chanSize),
-		globalResponses:  make(chan interface{}, 1),
+		globalResponses:  make(chan any, 1),
 		incomingRequests: make(chan *Request, chanSize),
 		errCond:          newCond(),
 	}
@@ -129,7 +129,7 @@ func newMux(p packetConn) *mux {
 	return m
 }
 
-func (m *mux) sendMessage(msg interface{}) error {
+func (m *mux) sendMessage(msg any) error {
 	p := Marshal(msg)
 	if debugMux {
 		log.Printf("send global(%d): %#v", m.chanList.offset, msg)

--- a/ssh/test/testdata_test.go
+++ b/ssh/test/testdata_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	testPrivateKeys map[string]interface{}
+	testPrivateKeys map[string]any
 	testSigners     map[string]ssh.Signer
 	testPublicKeys  map[string]ssh.PublicKey
 )
@@ -26,7 +26,7 @@ func init() {
 	var err error
 
 	n := len(testdata.PEMBytes)
-	testPrivateKeys = make(map[string]interface{}, n)
+	testPrivateKeys = make(map[string]any, n)
 	testSigners = make(map[string]ssh.Signer, n)
 	testPublicKeys = make(map[string]ssh.PublicKey, n)
 	for t, k := range testdata.PEMBytes {

--- a/ssh/testdata_test.go
+++ b/ssh/testdata_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	testPrivateKeys map[string]interface{}
+	testPrivateKeys map[string]any
 	testSigners     map[string]Signer
 	testPublicKeys  map[string]PublicKey
 )
@@ -25,7 +25,7 @@ func init() {
 	var err error
 
 	n := len(testdata.PEMBytes)
-	testPrivateKeys = make(map[string]interface{}, n)
+	testPrivateKeys = make(map[string]any, n)
 	testSigners = make(map[string]Signer, n)
 	testPublicKeys = make(map[string]PublicKey, n)
 	for t, k := range testdata.PEMBytes {

--- a/xts/xts.go
+++ b/xts/xts.go
@@ -43,7 +43,7 @@ type Cipher struct {
 const blockSize = 16
 
 var tweakPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new([blockSize]byte)
 	},
 }


### PR DESCRIPTION
Rewrite `interface{}`to `any`.

Reference: https://github.com/golang/go/issues/49884