### PR TITLE
ssh/agent: parse public key with ssh.ParsePublicKey

### DIFF
--- a/ssh/agent/server.go
+++ b/ssh/agent/server.go
@@ -123,13 +123,13 @@ func (s *server) processRequest(data []byte) (interface{}, error) {
 			return nil, err
 		}
 
-		k := &Key{
-			Format: wk.Format,
-			Blob:   req.KeyBlob,
+		var err error
+		k, err := ssh.ParsePublicKey(req.KeyBlob)
+		if err != nil {
+			return nil, err
 		}
 
 		var sig *ssh.Signature
-		var err error
 		if extendedAgent, ok := s.agent.(ExtendedAgent); ok {
 			sig, err = extendedAgent.SignWithFlags(k, req.Data, SignatureFlags(req.Flags))
 		} else {


### PR DESCRIPTION
When the server gets an `agentSignRequest` it can be `ssh.PublicKey` or `ssh.Certificate` formatted keys. As the server only parsed these into `ssh.Key` they would require a `Marshal()` to `ParsePublicKey()` dance when the passed key is a certificate.

Use `ssh.ParsePublicKey` instead of the `ssh.Key` struct directly.