### PR TITLE
cryptobyte: fix typo 'octects' into 'octets' for asn1.go

### DIFF
--- a/cryptobyte/asn1.go
+++ b/cryptobyte/asn1.go
@@ -234,7 +234,7 @@ func (b *Builder) AddASN1(tag asn1.Tag, f BuilderContinuation) {
 	// Identifiers with the low five bits set indicate high-tag-number format
 	// (two or more octets), which we don't support.
 	if tag&0x1f == 0x1f {
-		b.err = fmt.Errorf("cryptobyte: high-tag number identifier octects not supported: 0x%x", tag)
+		b.err = fmt.Errorf("cryptobyte: high-tag number identifier octets not supported: 0x%x", tag)
 		return
 	}
 	b.AddUint8(uint8(tag))


### PR DESCRIPTION
This typo ends up into lots of executables that trigger 'codespell'-style linter checks.