### PR TITLE
 x/crypto: bump golang.org/x/net to v0.33.0 for CVE-2024-45338

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module golang.org/x/crypto
 go 1.23.0
 
 require (
-	golang.org/x/net v0.21.0 // tagx:ignore
+	golang.org/x/net v0.33.0 // tagx:ignore
 	golang.org/x/sys v0.30.0
 	golang.org/x/term v0.29.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
-golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=


### PR DESCRIPTION
Fixes - https://github.com/advisories/GHSA-w32m-9786-jp63