### PR TITLE
x/crypto/acme/autocert: add support for ACME profiles and LetsEncrypt public ip certificates

### DIFF
--- a/acme/acme.go
+++ b/acme/acme.go
@@ -185,10 +185,11 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 		Nonce     string `json:"newNonce"`
 		KeyChange string `json:"keyChange"`
 		Meta      struct {
-			Terms        string   `json:"termsOfService"`
-			Website      string   `json:"website"`
-			CAA          []string `json:"caaIdentities"`
-			ExternalAcct bool     `json:"externalAccountRequired"`
+			Terms        string            `json:"termsOfService"`
+			Website      string            `json:"website"`
+			CAA          []string          `json:"caaIdentities"`
+			ExternalAcct bool              `json:"externalAccountRequired"`
+			Profiles     map[string]string `json:"profiles"`
 		}
 	}
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
@@ -208,6 +209,7 @@ func (c *Client) Discover(ctx context.Context) (Directory, error) {
 		Website:                 v.Meta.Website,
 		CAA:                     v.Meta.CAA,
 		ExternalAccountRequired: v.Meta.ExternalAcct,
+		Profiles:                v.Meta.Profiles,
 	}
 	return *c.dir, nil
 }
@@ -217,6 +219,20 @@ func (c *Client) directoryURL() string {
 		return c.DirectoryURL
 	}
 	return LetsEncryptURL
+}
+
+func (c *Client) validProfile(name string) bool {
+	// profile names are optional, so empty string ("") is valid
+	if name == "" {
+		return true
+	}
+	if len(c.dir.Profiles) == 0 {
+		// no profiles are supported so only valid name is empty string ("")
+		// which is caught above
+		return false
+	}
+	_, has := c.dir.Profiles[name]
+	return has
 }
 
 // CreateCert was part of the old version of ACME. It is incompatible with RFC 8555.

--- a/acme/autocert/autocert.go
+++ b/acme/autocert/autocert.go
@@ -26,6 +26,7 @@ import (
 	mathrand "math/rand"
 	"net"
 	"net/http"
+	"net/netip"
 	"path"
 	"strings"
 	"sync"
@@ -1061,8 +1062,11 @@ func (s *certState) tlscert() (*tls.Certificate, error) {
 func certRequest(key crypto.Signer, name string, ext []pkix.Extension) ([]byte, error) {
 	req := &x509.CertificateRequest{
 		Subject:         pkix.Name{CommonName: name},
-		DNSNames:        []string{name},
 		ExtraExtensions: ext,
+	}
+	// add name to DNSNames if name is not an IP address
+	if _, err := netip.ParseAddr(name); err != nil {
+		req.DNSNames = []string{name}
 	}
 	return x509.CreateCertificateRequest(rand.Reader, req, key)
 }

--- a/acme/autocert/autocert.go
+++ b/acme/autocert/autocert.go
@@ -26,7 +26,6 @@ import (
 	mathrand "math/rand"
 	"net"
 	"net/http"
-	"net/netip"
 	"path"
 	"strings"
 	"sync"
@@ -176,6 +175,14 @@ type Manager struct {
 	// account of the CA to which the ACME server is tied.
 	// See RFC 8555, Section 7.3.4 for more details.
 	ExternalAccountBinding *acme.ExternalAccountBinding
+
+	// Profile optional name of certificate profile to use when creating a new order
+	//
+	// available profiles are defined by the ACME server and listed in the
+	// ACME server's directory response.
+	//
+	// See RFC: https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/
+	Profile string
 
 	clientMu sync.Mutex
 	client   *acme.Client // initialized by acmeClient method
@@ -694,9 +701,16 @@ func (m *Manager) verifyRFC(ctx context.Context, client *acme.Client, domain str
 	// it will most likely not work on another order's authorization either.
 	challengeTypes := m.supportedChallengeTypes()
 	nextTyp := 0 // challengeTypes index
+	authOpts := []acme.OrderOption{acme.WithOrderProfile(m.Profile)}
 AuthorizeOrderLoop:
 	for {
-		o, err := client.AuthorizeOrder(ctx, acme.DomainIDs(domain))
+		var ids []acme.AuthzID
+		if ip := net.ParseIP(domain); ip != nil {
+			ids = acme.IPIDs(domain)
+		} else {
+			ids = acme.DomainIDs(domain)
+		}
+		o, err := client.AuthorizeOrder(ctx, ids, authOpts...)
 		if err != nil {
 			return nil, err
 		}
@@ -1061,12 +1075,14 @@ func (s *certState) tlscert() (*tls.Certificate, error) {
 // certRequest generates a CSR for the given common name.
 func certRequest(key crypto.Signer, name string, ext []pkix.Extension) ([]byte, error) {
 	req := &x509.CertificateRequest{
-		Subject:         pkix.Name{CommonName: name},
+		Subject:         pkix.Name{},
 		ExtraExtensions: ext,
 	}
-	// add name to DNSNames if name is not an IP address
-	if _, err := netip.ParseAddr(name); err != nil {
+	if ip := net.ParseIP(name); ip != nil {
+		req.IPAddresses = []net.IP{ip}
+	} else {
 		req.DNSNames = []string{name}
+		req.Subject.CommonName = name
 	}
 	return x509.CreateCertificateRequest(rand.Reader, req, key)
 }

--- a/acme/rfc8555.go
+++ b/acme/rfc8555.go
@@ -208,6 +208,7 @@ func (c *Client) AuthorizeOrder(ctx context.Context, id []AuthzID, opt ...OrderO
 		Identifiers []wireAuthzID `json:"identifiers"`
 		NotBefore   string        `json:"notBefore,omitempty"`
 		NotAfter    string        `json:"notAfter,omitempty"`
+		Profile     string        `json:"profile,omitempty"`
 	}{}
 	for _, v := range id {
 		req.Identifiers = append(req.Identifiers, wireAuthzID{
@@ -221,6 +222,11 @@ func (c *Client) AuthorizeOrder(ctx context.Context, id []AuthzID, opt ...OrderO
 			req.NotBefore = time.Time(o).Format(time.RFC3339)
 		case orderNotAfterOpt:
 			req.NotAfter = time.Time(o).Format(time.RFC3339)
+		case orderProfileOpt:
+			req.Profile = string(o)
+			if !c.validProfile(req.Profile) {
+				return nil, fmt.Errorf("invalid acme profile: %s", req.Profile)
+			}
 		default:
 			// Package's fault if we let this happen.
 			panic(fmt.Sprintf("unsupported order option type %T", o))
@@ -308,6 +314,7 @@ func responseOrder(res *http.Response) (*Order, error) {
 		Authorizations []string
 		Finalize       string
 		Certificate    string
+		Profile        string
 	}
 	if err := json.NewDecoder(res.Body).Decode(&v); err != nil {
 		return nil, fmt.Errorf("acme: error reading order: %v", err)
@@ -321,6 +328,7 @@ func responseOrder(res *http.Response) (*Order, error) {
 		AuthzURLs:   v.Authorizations,
 		FinalizeURL: v.Finalize,
 		CertURL:     v.Certificate,
+		Profile:     v.Profile,
 	}
 	for _, id := range v.Identifiers {
 		o.Identifiers = append(o.Identifiers, AuthzID{Type: id.Type, Value: id.Value})

--- a/acme/types.go
+++ b/acme/types.go
@@ -311,6 +311,9 @@ type Directory struct {
 	// ExternalAccountRequired indicates that the CA requires for all account-related
 	// requests to include external account binding information.
 	ExternalAccountRequired bool
+
+	// Profiles the certificate profiles which are supported by the ACME server
+	Profiles map[string]string
 }
 
 // Order represents a client's request for a certificate.
@@ -344,6 +347,13 @@ type Order struct {
 
 	// NotAfter is the requested value of the notAfter field in the certificate.
 	NotAfter time.Time
+
+	// Profile the certificate profile to use with the order (optional)
+	// available profiles are defined by the ACME server and listed in the
+	// ACME server's directory response.
+	//
+	// RFC: https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/
+	Profile string
 
 	// AuthzURLs represents authorizations to complete before a certificate
 	// for identifiers specified in the order can be issued.
@@ -386,6 +396,11 @@ func WithOrderNotAfter(t time.Time) OrderOption {
 	return orderNotAfterOpt(t)
 }
 
+// WithOrderProfile sets tthe order's Profile field.
+func WithOrderProfile(p string) OrderOption {
+	return orderProfileOpt(p)
+}
+
 type orderNotBeforeOpt time.Time
 
 func (orderNotBeforeOpt) privateOrderOpt() {}
@@ -393,6 +408,10 @@ func (orderNotBeforeOpt) privateOrderOpt() {}
 type orderNotAfterOpt time.Time
 
 func (orderNotAfterOpt) privateOrderOpt() {}
+
+type orderProfileOpt string
+
+func (orderProfileOpt) privateOrderOpt() {}
 
 // Authorization encodes an authorization response.
 type Authorization struct {


### PR DESCRIPTION
This PR adds support for automated management of ACME certificates for public ip addresses.

In July 2025, LetsEncrypt announced the first certificate for a public ip address (https://letsencrypt.org/2025/07/01/issuing-our-first-ip-address-certificate) 
and their intention to support short lived certificates for public ip addresses.

In December 2025, LetsEncrypt announced general availability of certificates 
for public ip addresses in production (https://community.letsencrypt.org/t/upcoming-changes-to-let-s-encrypt-certificates/243873).

These type of certificates are particularly helpful for infrastructure projects that 
have a static public ip address but no domain name and need to create a secure 
and trusted connection with external clients (like one of the projects that I'm working on).

In order for LetsEncrypt to issue a certificate for a public ip address, one of the 
requirements is that the "shortlived" (https://letsencrypt.org/docs/profiles/#shortlived) 
profile be used when ordering the certificate.

Profiles are a relatively new addition to the ACME protocol, but a Draft RFC (https://datatracker.ietf.org/doc/draft-aaron-acme-profiles/) 
does exist.  I did not research if any ACME providers other than LetsEncrypt support 
this Draft RFC, but a) LetsEncrypt does, b) this package seems primarily intended to 
work with LetsEncrypt, and c) supporting profiles via the Draft RFC does not impact 
existing functionality for other ACME providers that don't support profiles.

In order to manage certificates for public ip addresses using this PR, you a) add the 
"shortlived" profile when defining the "autocert.Manager", b) add a public ip address 
to the manager's "HostPolicy", and c) wrap the manager's "tlsConf.GetCertificate" 
function to set the "clientHello.ServerName" to the public ip address as most browsers/clients 
do not set the SNI server name for a request to an ip address.

For example:

publicIp := "xxx.xxx.xxx.xxx"

manager := &autocert.Manager{
    ...
    HostPolicy: autocert.HostWhiteList(publicIp),
    Profile:    "shortlived",
    ...
}

tlsConfig := &tls.Config{
    ...
    NextProtos:     manager.NextProtos,
    GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
        if hello.ServerName == "" {
            // if SNI is not set, assume the request was made to the public ip address
            hello.ServerName = publicIp
        }
        return manager.GetCertificate(hello)
    },
    ...
}


This PR is currently in use in one of the infrastructure projects I'm working on and is successfully 
managing short lived LetsEncrypt certificates for public ip addresses.

I would love to get feedback on the implementation and ultimately see this functionality get added 
to the "x/crypto/acme" and "x/crypto/acme/autocert" packages as I'm sure I'm not the only one 
whose projects would benefit from this feature.