### PR TITLE
ssh: reject incomplete gssapi-with-mic configurations

### DIFF
--- a/ssh/client_auth_test.go
+++ b/ssh/client_auth_test.go
@@ -971,6 +971,155 @@ func TestAuthMethodGSSAPIWithMIC(t *testing.T) {
 	}
 }
 
+type maliciousGSSAPIWithMICAuthMethod struct {
+	gssAPIClient GSSAPIClient
+	target       string
+}
+
+func (g *maliciousGSSAPIWithMICAuthMethod) method() string {
+	// Reuse an advertised auth method name so the client attempts this
+	// AuthMethod even when gssapi-with-mic is not advertised.
+	return "password"
+}
+
+func (g *maliciousGSSAPIWithMICAuthMethod) auth(session []byte, user string, c packetConn, rand io.Reader, _ map[string][]byte) (authResult, []string, error) {
+	req := &userAuthRequestMsg{
+		User:    user,
+		Service: serviceSSH,
+		Method:  "gssapi-with-mic",
+	}
+	req.Payload = appendU32(req.Payload, 1)
+	req.Payload = appendString(req.Payload, string(krb5OID))
+	if err := c.writePacket(Marshal(req)); err != nil {
+		return authFailure, nil, err
+	}
+
+	packet, err := c.readPacket()
+	if err != nil {
+		return authFailure, nil, err
+	}
+	switch packet[0] {
+	case msgUserAuthFailure:
+		var msg userAuthFailureMsg
+		if err := Unmarshal(packet, &msg); err != nil {
+			return authFailure, nil, err
+		}
+		if msg.PartialSuccess {
+			return authPartialSuccess, msg.Methods, nil
+		}
+		return authFailure, msg.Methods, nil
+	case msgUserAuthGSSAPIResponse:
+	default:
+		return authFailure, nil, unexpectedMessageError(msgUserAuthGSSAPIResponse, packet[0])
+	}
+
+	defer g.gssAPIClient.DeleteSecContext()
+	var token []byte
+	for {
+		nextToken, needContinue, err := g.gssAPIClient.InitSecContext("host@"+g.target, token, false)
+		if err != nil {
+			return authFailure, nil, err
+		}
+		if len(nextToken) > 0 {
+			if err := c.writePacket(Marshal(&userAuthGSSAPIToken{Token: nextToken})); err != nil {
+				return authFailure, nil, err
+			}
+		}
+		if !needContinue {
+			break
+		}
+		packet, err = c.readPacket()
+		if err != nil {
+			return authFailure, nil, err
+		}
+		switch packet[0] {
+		case msgUserAuthFailure:
+			var msg userAuthFailureMsg
+			if err := Unmarshal(packet, &msg); err != nil {
+				return authFailure, nil, err
+			}
+			if msg.PartialSuccess {
+				return authPartialSuccess, msg.Methods, nil
+			}
+			return authFailure, msg.Methods, nil
+		case msgUserAuthGSSAPIError:
+			userAuthGSSAPIErrorResp := &userAuthGSSAPIError{}
+			if err := Unmarshal(packet, userAuthGSSAPIErrorResp); err != nil {
+				return authFailure, nil, err
+			}
+			return authFailure, nil, fmt.Errorf("GSS-API Error:\nMajor Status: %d\nMinor Status: %d\nError Message: %s\n",
+				userAuthGSSAPIErrorResp.MajorStatus, userAuthGSSAPIErrorResp.MinorStatus, userAuthGSSAPIErrorResp.Message)
+		case msgUserAuthGSSAPIToken:
+			userAuthGSSAPITokenReq := &userAuthGSSAPIToken{}
+			if err := Unmarshal(packet, userAuthGSSAPITokenReq); err != nil {
+				return authFailure, nil, err
+			}
+			token = userAuthGSSAPITokenReq.Token
+		default:
+			return authFailure, nil, unexpectedMessageError(msgUserAuthGSSAPIToken, packet[0])
+		}
+	}
+
+	micField := buildMIC(string(session), user, serviceSSH, "gssapi-with-mic")
+	micToken, err := g.gssAPIClient.GetMIC(micField)
+	if err != nil {
+		return authFailure, nil, err
+	}
+	if err := c.writePacket(Marshal(&userAuthGSSAPIMIC{MIC: micToken})); err != nil {
+		return authFailure, nil, err
+	}
+	return handleAuthResponse(c)
+}
+
+func TestGSSAPIWithMICPartialConfigRejectedAtRuntime(t *testing.T) {
+	config := &ClientConfig{
+		User: "testuser",
+		Auth: []AuthMethod{
+			&maliciousGSSAPIWithMICAuthMethod{
+				gssAPIClient: &FakeClient{
+					exchanges: []*exchange{
+						{
+							outToken: "client-valid-token-1",
+						},
+					},
+					mic:      []byte("valid-mic"),
+					maxRound: 1,
+				},
+				target: "testtarget",
+			},
+		},
+		HostKeyCallback: InsecureIgnoreHostKey(),
+	}
+
+	clientErr, serverErrs := tryAuthBothSides(t, config, &GSSAPIWithMICConfig{
+		Server: &FakeServer{
+			exchanges: []*exchange{
+				{
+					expectedToken: "client-valid-token-1",
+				},
+			},
+			maxRound:    1,
+			expectedMIC: []byte("valid-mic"),
+			srcName:     "testuser@DOMAIN",
+		},
+	})
+
+	if clientErr == nil || !strings.Contains(clientErr.Error(), "ssh: unable to authenticate") {
+		t.Fatalf("client got %v, want authentication failure", clientErr)
+	}
+
+	found := false
+	for _, err := range serverErrs {
+		if err != nil && strings.Contains(err.Error(), "ssh: gssapi-with-mic auth not configured") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("server auth errors = %v, want gssapi-with-mic auth not configured", serverErrs)
+	}
+}
+
 func TestCompatibleAlgoAndSignatures(t *testing.T) {
 	type testcase struct {
 		algo       string

--- a/ssh/client_auth_test.go
+++ b/ssh/client_auth_test.go
@@ -971,18 +971,15 @@ func TestAuthMethodGSSAPIWithMIC(t *testing.T) {
 	}
 }
 
-type maliciousGSSAPIWithMICAuthMethod struct {
-	gssAPIClient GSSAPIClient
-	target       string
-}
+type maliciousGSSAPIWithMICAuthMethod struct{}
 
-func (g *maliciousGSSAPIWithMICAuthMethod) method() string {
+func (maliciousGSSAPIWithMICAuthMethod) method() string {
 	// Reuse an advertised auth method name so the client attempts this
 	// AuthMethod even when gssapi-with-mic is not advertised.
 	return "password"
 }
 
-func (g *maliciousGSSAPIWithMICAuthMethod) auth(session []byte, user string, c packetConn, rand io.Reader, _ map[string][]byte) (authResult, []string, error) {
+func (maliciousGSSAPIWithMICAuthMethod) auth(session []byte, user string, c packetConn, rand io.Reader, _ map[string][]byte) (authResult, []string, error) {
 	req := &userAuthRequestMsg{
 		User:    user,
 		Service: serviceSSH,
@@ -1008,100 +1005,22 @@ func (g *maliciousGSSAPIWithMICAuthMethod) auth(session []byte, user string, c p
 			return authPartialSuccess, msg.Methods, nil
 		}
 		return authFailure, msg.Methods, nil
-	case msgUserAuthGSSAPIResponse:
 	default:
-		return authFailure, nil, unexpectedMessageError(msgUserAuthGSSAPIResponse, packet[0])
+		return authFailure, nil, unexpectedMessageError(msgUserAuthFailure, packet[0])
 	}
-
-	defer g.gssAPIClient.DeleteSecContext()
-	var token []byte
-	for {
-		nextToken, needContinue, err := g.gssAPIClient.InitSecContext("host@"+g.target, token, false)
-		if err != nil {
-			return authFailure, nil, err
-		}
-		if len(nextToken) > 0 {
-			if err := c.writePacket(Marshal(&userAuthGSSAPIToken{Token: nextToken})); err != nil {
-				return authFailure, nil, err
-			}
-		}
-		if !needContinue {
-			break
-		}
-		packet, err = c.readPacket()
-		if err != nil {
-			return authFailure, nil, err
-		}
-		switch packet[0] {
-		case msgUserAuthFailure:
-			var msg userAuthFailureMsg
-			if err := Unmarshal(packet, &msg); err != nil {
-				return authFailure, nil, err
-			}
-			if msg.PartialSuccess {
-				return authPartialSuccess, msg.Methods, nil
-			}
-			return authFailure, msg.Methods, nil
-		case msgUserAuthGSSAPIError:
-			userAuthGSSAPIErrorResp := &userAuthGSSAPIError{}
-			if err := Unmarshal(packet, userAuthGSSAPIErrorResp); err != nil {
-				return authFailure, nil, err
-			}
-			return authFailure, nil, fmt.Errorf("GSS-API Error:\nMajor Status: %d\nMinor Status: %d\nError Message: %s\n",
-				userAuthGSSAPIErrorResp.MajorStatus, userAuthGSSAPIErrorResp.MinorStatus, userAuthGSSAPIErrorResp.Message)
-		case msgUserAuthGSSAPIToken:
-			userAuthGSSAPITokenReq := &userAuthGSSAPIToken{}
-			if err := Unmarshal(packet, userAuthGSSAPITokenReq); err != nil {
-				return authFailure, nil, err
-			}
-			token = userAuthGSSAPITokenReq.Token
-		default:
-			return authFailure, nil, unexpectedMessageError(msgUserAuthGSSAPIToken, packet[0])
-		}
-	}
-
-	micField := buildMIC(string(session), user, serviceSSH, "gssapi-with-mic")
-	micToken, err := g.gssAPIClient.GetMIC(micField)
-	if err != nil {
-		return authFailure, nil, err
-	}
-	if err := c.writePacket(Marshal(&userAuthGSSAPIMIC{MIC: micToken})); err != nil {
-		return authFailure, nil, err
-	}
-	return handleAuthResponse(c)
 }
 
 func TestGSSAPIWithMICPartialConfigRejectedAtRuntime(t *testing.T) {
 	config := &ClientConfig{
 		User: "testuser",
 		Auth: []AuthMethod{
-			&maliciousGSSAPIWithMICAuthMethod{
-				gssAPIClient: &FakeClient{
-					exchanges: []*exchange{
-						{
-							outToken: "client-valid-token-1",
-						},
-					},
-					mic:      []byte("valid-mic"),
-					maxRound: 1,
-				},
-				target: "testtarget",
-			},
+			maliciousGSSAPIWithMICAuthMethod{},
 		},
 		HostKeyCallback: InsecureIgnoreHostKey(),
 	}
 
 	clientErr, serverErrs := tryAuthBothSides(t, config, &GSSAPIWithMICConfig{
-		Server: &FakeServer{
-			exchanges: []*exchange{
-				{
-					expectedToken: "client-valid-token-1",
-				},
-			},
-			maxRound:    1,
-			expectedMIC: []byte("valid-mic"),
-			srcName:     "testuser@DOMAIN",
-		},
+		Server: &FakeServer{},
 	})
 
 	if clientErr == nil || !strings.Contains(clientErr.Error(), "ssh: unable to authenticate") {

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -49,6 +49,9 @@ type Permissions struct {
 	ExtraData map[any]any
 }
 
+// GSSAPIWithMICConfig includes the server callbacks for gssapi-with-mic
+// authentication. If either field is nil, gssapi-with-mic is considered not
+// configured.
 type GSSAPIWithMICConfig struct {
 	// AllowLogin, must be set, is called when gssapi-with-mic
 	// authentication is selected (RFC 4462 section 3). The srcName is from the

--- a/ssh/server.go
+++ b/ssh/server.go
@@ -63,6 +63,10 @@ type GSSAPIWithMICConfig struct {
 	Server GSSAPIServer
 }
 
+func gssapiWithMICConfigured(config *GSSAPIWithMICConfig) bool {
+	return config != nil && config.AllowLogin != nil && config.Server != nil
+}
+
 // SendAuthBanner implements [ServerPreAuthConn].
 func (s *connection) SendAuthBanner(msg string) error {
 	return s.transport.writePacket(Marshal(&userAuthBannerMsg{
@@ -302,8 +306,7 @@ func (s *connection) serverHandshake(config *ServerConfig) (*Permissions, error)
 	}
 
 	if !config.NoClientAuth && config.PasswordCallback == nil && config.PublicKeyCallback == nil &&
-		config.KeyboardInteractiveCallback == nil && (config.GSSAPIWithMICConfig == nil ||
-		config.GSSAPIWithMICConfig.AllowLogin == nil || config.GSSAPIWithMICConfig.Server == nil) {
+		config.KeyboardInteractiveCallback == nil && !gssapiWithMICConfigured(config.GSSAPIWithMICConfig) {
 		return nil, errors.New("ssh: no authentication methods configured but NoClientAuth is also false")
 	}
 
@@ -752,7 +755,7 @@ userAuthLoop:
 				}
 			}
 		case "gssapi-with-mic":
-			if authConfig.GSSAPIWithMICConfig == nil {
+			if !gssapiWithMICConfigured(authConfig.GSSAPIWithMICConfig) {
 				authErr = errors.New("ssh: gssapi-with-mic auth not configured")
 				break
 			}
@@ -878,8 +881,7 @@ userAuthLoop:
 		if authConfig.KeyboardInteractiveCallback != nil {
 			failureMsg.Methods = append(failureMsg.Methods, "keyboard-interactive")
 		}
-		if authConfig.GSSAPIWithMICConfig != nil && authConfig.GSSAPIWithMICConfig.Server != nil &&
-			authConfig.GSSAPIWithMICConfig.AllowLogin != nil {
+		if gssapiWithMICConfigured(authConfig.GSSAPIWithMICConfig) {
 			failureMsg.Methods = append(failureMsg.Methods, "gssapi-with-mic")
 		}
 


### PR DESCRIPTION
Make the runtime gssapi-with-mic guard match the existing
configuration and method advertisement checks.

An incomplete GSSAPIWithMICConfig can be treated as unavailable when
building the advertised auth method list, while still remaining
reachable from the runtime auth dispatcher. Treat incomplete
configurations as not configured.

This change introduces a single internal completeness check for
GSSAPIWithMICConfig and uses it for the startup authentication
validation, the runtime gssapi-with-mic dispatch guard, and the
advertised authentication method list.

The change also adds a regression test. The test configures a server
with a normal PasswordCallback, a GSSAPIWithMICConfig with Server set,
and AllowLogin intentionally unset. It then uses a custom client auth
method that explicitly sends a USERAUTH_REQUEST with Method set to
gssapi-with-mic even though the server does not advertise that method,
and verifies that authentication fails cleanly with
"ssh: gssapi-with-mic auth not configured".

No golang/go issue reference is available yet.
