### PR TITLE
openpgp/elgamal: fix index out of range panic in Decrypt when ciphertext is zero

### DIFF
--- a/openpgp/elgamal/elgamal.go
+++ b/openpgp/elgamal/elgamal.go
@@ -89,6 +89,9 @@ func Decrypt(priv *PrivateKey, c1, c2 *big.Int) (msg []byte, err error) {
 	s.Mod(s, priv.P)
 	em := s.Bytes()
 
+	if len(em) == 0 {
+		return nil, errors.New("elgamal: decryption error")
+	}
 	firstByteIsTwo := subtle.ConstantTimeByteEq(em[0], 2)
 
 	// The remainder of the plaintext must be a string of non-zero random

--- a/openpgp/elgamal/elgamal_test.go
+++ b/openpgp/elgamal/elgamal_test.go
@@ -62,3 +62,14 @@ func TestDecryptBadKey(t *testing.T) {
 		t.Errorf("unexpected success decrypting")
 	}
 }
+
+func TestDecryptZeroCiphertext(t *testing.T) {
+	priv, err := GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Decrypt(priv, big.NewInt(2), big.NewInt(0))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
Decrypt panics when the recovered value s equals zero because
s.Bytes() returns an empty slice and em[0] is indexed without
a bounds check.

An attacker can force s=0 by supplying c2=0 in a crafted
OpenPGP PKESK packet, causing a denial of service.

Fix: check len(em) == 0 before indexing and return an error.

Fixes golang/go#79841
Fixes: https://issuetracker.google.com/issues/519383708