### PR TITLE
pkcs12: reject unsafe PBKDF iteration counts to prevent CPU exhaustion

### DIFF
--- a/pkcs12/crypto.go
+++ b/pkcs12/crypto.go
@@ -80,9 +80,11 @@ func pbDecrypterFor(algorithm pkix.AlgorithmIdentifier, password []byte) (cipher
 		return nil, 0, err
 	}
 
+	if params.Iterations <= 0 || params.Iterations > 10_000_000 {
+		return nil, 0, errors.New("pkcs12: iteration count out of safe range")
+	}
 	key := cipherType.deriveKey(params.Salt, password, params.Iterations)
 	iv := cipherType.deriveIV(params.Salt, password, params.Iterations)
-
 	block, err := cipherType.create(key)
 	if err != nil {
 		return nil, 0, err

--- a/pkcs12/mac.go
+++ b/pkcs12/mac.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha1"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"errors"
 )
 
 type macData struct {
@@ -31,7 +32,9 @@ func verifyMac(macData *macData, message, password []byte) error {
 	if !macData.Mac.Algorithm.Algorithm.Equal(oidSHA1) {
 		return NotImplementedError("unknown digest algorithm: " + macData.Mac.Algorithm.Algorithm.String())
 	}
-
+	if macData.Iterations <= 0 || macData.Iterations > 10_000_000 {
+		return errors.New("pkcs12: iteration count out of safe range")
+	}
 	key := pbkdf(sha1Sum, 20, 64, macData.MacSalt, password, macData.Iterations, 3, 20)
 
 	mac := hmac.New(sha1.New, key)

--- a/pkcs12/pkcs12_test.go
+++ b/pkcs12/pkcs12_test.go
@@ -139,3 +139,12 @@ p8SsTugkit8wOwYJKoZIhvcNAQkUMS4eLABGAHIAaQBlAG4AZABsAHkAIABuAGEAbQBlACAAZgBv
 AHIAIABjAGUAcgB0MDEwITAJBgUrDgMCGgUABBRFsNz3Zd1O1GI8GTuFwCWuDOjEEwQIuBEfIcAy
 HQ8CAggA`,
 }
+
+func TestDecodeHugeIterationCount(t *testing.T) {
+	// Minimal PFX with Iterations = 2^31
+	// Should return error, not hang
+	_, _, err := Decode(hugeIterPFX, "password")
+	if err == nil {
+		t.Fatal("expected error for huge iteration count, got nil")
+	}
+}


### PR DESCRIPTION
pkcs12: cap PBKDF iteration count to prevent CPU exhaustion

macData.Iterations is parsed from untrusted PFX input and passed
to pbkdf() without an upper bound. An attacker can set
Iterations=2^63-1 to tie up a CPU core indefinitely before any
MAC or password verification occurs.

Fix: reject Iterations outside (0, 10_000_000] in both verifyMac
and pbDecrypt.

Fixes golang/go#79798