### PR TITLE
openpgp/packet: reject too-short decrypted session key in EncryptedKey.Decrypt

### DIFF
--- a/openpgp/packet/encrypted_key.go
+++ b/openpgp/packet/encrypted_key.go
@@ -94,6 +94,14 @@ func (e *EncryptedKey) Decrypt(priv *PrivateKey, config *Config) error {
 		return err
 	}
 
+	// The decrypted session key is one cipher-algorithm octet, the key
+	// material, and a two-octet checksum. A decryption that yields fewer than
+	// three octets (e.g. from a crafted ElGamal/RSA/ECDH ciphertext) would
+	// otherwise make the indexing below panic with slice/index out of range.
+	if len(b) < 3 {
+		return errors.StructuralError("session key is too short")
+	}
+
 	e.CipherFunc = CipherFunction(b[0])
 	e.Key = b[1 : len(b)-2]
 	expectedChecksum := uint16(b[len(b)-2])<<8 | uint16(b[len(b)-1])


### PR DESCRIPTION
EncryptedKey.Decrypt (openpgp/packet/encrypted_key.go) decrypts a
public-key-encrypted session key and then reads it without any length
check:

    e.CipherFunc = CipherFunction(b[0])
    e.Key = b[1 : len(b)-2]
    expectedChecksum := uint16(b[len(b)-2])<<8 | uint16(b[len(b)-1])

b is the result of RSA, ElGamal or ECDH decryption. A crafted
public-key-encrypted message whose ciphertext decrypts to fewer than
three octets makes these operations panic: len(b)==0 panics on b[0],
and len(b)<3 panics on b[1:len(b)-2] (e.g. b[1:0]). This is reachable
from ReadMessage when decrypting an attacker-supplied message with the
recipient's private key, a denial of service for any program that
decrypts untrusted OpenPGP messages.

The fix rejects len(b) < 3 with a StructuralError before indexing. A
valid session key is one cipher-algorithm octet plus key material plus
a two-octet checksum, so three octets is the minimum. This complements
PR #348 (which guards elgamal.Decrypt against an empty result): the
caller still needs at least the cipher octet plus the two checksum
octets, and the RSA and ECDH decryption paths were unguarded entirely.
