### PR TITLE
ssh/knownhosts: fix wildcard matching off-by-one

### DIFF
--- a/ssh/knownhosts/knownhosts.go
+++ b/ssh/knownhosts/knownhosts.go
@@ -80,9 +80,6 @@ func wildcardMatch(pat []byte, str []byte) bool {
 		if len(pat) == 0 {
 			return len(str) == 0
 		}
-		if len(str) == 0 {
-			return false
-		}
 
 		if pat[0] == '*' {
 			if len(pat) == 1 {
@@ -94,6 +91,10 @@ func wildcardMatch(pat []byte, str []byte) bool {
 					return true
 				}
 			}
+			return false
+		}
+
+		if len(str) == 0 {
 			return false
 		}
 

--- a/ssh/knownhosts/knownhosts_test.go
+++ b/ssh/knownhosts/knownhosts_test.go
@@ -267,6 +267,12 @@ func TestWildcardMatch(t *testing.T) {
 		{"a*b*z", "axxbxxbxxxz", true},
 		{"a*b*z", "axxbxxzxxxz", true},
 		{"a*b*z", "axxbxxzxxx", false},
+		{"server*", "server", true},
+		{"*server", "server", true},
+		{"*", "", true},
+		{"*", "anything", true},
+		{"a*", "a", true},
+		{"*a", "a", true},
 	} {
 		got := wildcardMatch([]byte(c.pat), []byte(c.str))
 		if got != c.want {


### PR DESCRIPTION
Fixes #78038. The matching function returns early before checking if the current pattern character is a wildcard *, causing KeyError for valid patterns like server*.