### PR TITLE
crypto/ocsp: clarify ParseRequest multi-request behavior

### DIFF
--- a/ocsp/ocsp.go
+++ b/ocsp/ocsp.go
@@ -417,8 +417,11 @@ func (p ParseError) Error() string {
 	return string(p)
 }
 
-// ParseRequest parses an OCSP request in DER form. It only supports
-// requests for a single certificate. Signed requests are not supported.
+// ParseRequest parses an OCSP request in DER form.
+// It only supports requests for a single certificate.
+// If the request contains multiple requests, ParseRequest will use the first
+// request and ignore the rest.
+// Signed requests are not supported.
 // If a request includes a signature, it will result in a ParseError.
 func ParseRequest(bytes []byte) (*Request, error) {
 	var req ocspRequest


### PR DESCRIPTION
## Summary
Clarify `crypto/ocsp.ParseRequest` documentation for behavior when parsing multiple requests.

## Changes
- Update docs in `ocsp/ocsp.go` for `ParseRequest` comment.
- Explain expected error handling and behavior for multi-request payloads.

## Testing
- Not run (documentation-only change).