### PR TITLE
ocsp: match full CertID when issuer is provided

### DIFF
--- a/ocsp/ocsp.go
+++ b/ocsp/ocsp.go
@@ -8,6 +8,7 @@
 package ocsp
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -277,6 +278,25 @@ func getOIDFromHashAlgorithm(target crypto.Hash) asn1.ObjectIdentifier {
 	}
 	return nil
 }
+func issuerHashes(hashFunc crypto.Hash, issuer *x509.Certificate) (issuerNameHash, issuerKeyHash []byte, err error) {
+	var publicKeyInfo struct {
+		Algorithm pkix.AlgorithmIdentifier
+		PublicKey asn1.BitString
+	}
+	if _, err := asn1.Unmarshal(issuer.RawSubjectPublicKeyInfo, &publicKeyInfo); err != nil {
+		return nil, nil, err
+	}
+
+	h := hashFunc.New()
+	h.Write(publicKeyInfo.PublicKey.RightAlign())
+	issuerKeyHash = h.Sum(nil)
+
+	h.Reset()
+	h.Write(issuer.RawSubject)
+	issuerNameHash = h.Sum(nil)
+
+	return issuerNameHash, issuerKeyHash, nil
+}
 
 // This is the exposed reflection of the internal OCSP structures.
 
@@ -470,18 +490,20 @@ func ParseRequest(bytes []byte) (*Request, error) {
 //
 // Invalid responses and parse failures will result in a ParseError.
 // Error responses will result in a ResponseError.
-func ParseResponse(bytes []byte, issuer *x509.Certificate) (*Response, error) {
-	return ParseResponseForCert(bytes, nil, issuer)
+func ParseResponse(der []byte, issuer *x509.Certificate) (*Response, error) {
+	return ParseResponseForCert(der, nil, issuer)
 }
 
 // ParseResponseForCert acts identically to ParseResponse, except it supports
 // parsing responses that contain multiple statuses. If the response contains
 // multiple statuses and cert is not nil, then ParseResponseForCert will return
-// the first status which contains a matching serial, otherwise it will return an
-// error. If cert is nil, then the first status in the response will be returned.
-func ParseResponseForCert(bytes []byte, cert, issuer *x509.Certificate) (*Response, error) {
+// the first status whose serial matches cert and, if issuer is not nil, whose
+// issuer name hash and issuer key hash also match issuer. Otherwise it will
+// return an error. If cert is nil, then the first status in the response will
+// be returned.
+func ParseResponseForCert(der []byte, cert, issuer *x509.Certificate) (*Response, error) {
 	var resp responseASN1
-	rest, err := asn1.Unmarshal(bytes, &resp)
+	rest, err := asn1.Unmarshal(der, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -516,11 +538,30 @@ func ParseResponseForCert(bytes []byte, cert, issuer *x509.Certificate) (*Respon
 	} else {
 		match := false
 		for _, resp := range basicResp.TBSResponseData.Responses {
-			if cert.SerialNumber.Cmp(resp.CertID.SerialNumber) == 0 {
+			if cert.SerialNumber.Cmp(resp.CertID.SerialNumber) != 0 {
+				continue
+			}
+			if issuer == nil {
 				singleResp = resp
 				match = true
 				break
 			}
+
+			hashFunc := getHashAlgorithmFromOID(resp.CertID.HashAlgorithm.Algorithm)
+			if hashFunc == 0 {
+				continue
+			}
+			issuerNameHash, issuerKeyHash, err := issuerHashes(hashFunc, issuer)
+			if err != nil {
+				return nil, err
+			}
+			if !bytes.Equal(resp.CertID.NameHash, issuerNameHash) || !bytes.Equal(resp.CertID.IssuerKeyHash, issuerKeyHash) {
+				continue
+			}
+
+			singleResp = resp
+			match = true
+			break
 		}
 		if !match {
 			return nil, ParseError("no response matching the supplied certificate")
@@ -528,7 +569,7 @@ func ParseResponseForCert(bytes []byte, cert, issuer *x509.Certificate) (*Respon
 	}
 
 	ret := &Response{
-		Raw:                bytes,
+		Raw:                der,
 		TBSResponseData:    basicResp.TBSResponseData.Raw,
 		Signature:          basicResp.Signature.RightAlign(),
 		SignatureAlgorithm: getSignatureAlgorithmFromOID(basicResp.SignatureAlgorithm.Algorithm),
@@ -647,22 +688,10 @@ func CreateRequest(cert, issuer *x509.Certificate, opts *RequestOptions) ([]byte
 	if !hashFunc.Available() {
 		return nil, x509.ErrUnsupportedAlgorithm
 	}
-	h := opts.hash().New()
-
-	var publicKeyInfo struct {
-		Algorithm pkix.AlgorithmIdentifier
-		PublicKey asn1.BitString
-	}
-	if _, err := asn1.Unmarshal(issuer.RawSubjectPublicKeyInfo, &publicKeyInfo); err != nil {
+	issuerNameHash, issuerKeyHash, err := issuerHashes(hashFunc, issuer)
+	if err != nil {
 		return nil, err
 	}
-
-	h.Write(publicKeyInfo.PublicKey.RightAlign())
-	issuerKeyHash := h.Sum(nil)
-
-	h.Reset()
-	h.Write(issuer.RawSubject)
-	issuerNameHash := h.Sum(nil)
 
 	req := &Request{
 		HashAlgorithm:  hashFunc,
@@ -688,14 +717,6 @@ func CreateRequest(cert, issuer *x509.Certificate, opts *RequestOptions) ([]byte
 //
 // The ProducedAt date is automatically set to the current date, to the nearest minute.
 func CreateResponse(issuer, responderCert *x509.Certificate, template Response, priv crypto.Signer) ([]byte, error) {
-	var publicKeyInfo struct {
-		Algorithm pkix.AlgorithmIdentifier
-		PublicKey asn1.BitString
-	}
-	if _, err := asn1.Unmarshal(issuer.RawSubjectPublicKeyInfo, &publicKeyInfo); err != nil {
-		return nil, err
-	}
-
 	if template.IssuerHash == 0 {
 		template.IssuerHash = crypto.SHA1
 	}
@@ -707,13 +728,10 @@ func CreateResponse(issuer, responderCert *x509.Certificate, template Response, 
 	if !template.IssuerHash.Available() {
 		return nil, fmt.Errorf("issuer hash algorithm %v not linked into binary", template.IssuerHash)
 	}
-	h := template.IssuerHash.New()
-	h.Write(publicKeyInfo.PublicKey.RightAlign())
-	issuerKeyHash := h.Sum(nil)
-
-	h.Reset()
-	h.Write(issuer.RawSubject)
-	issuerNameHash := h.Sum(nil)
+	issuerNameHash, issuerKeyHash, err := issuerHashes(template.IssuerHash, issuer)
+	if err != nil {
+		return nil, err
+	}
 
 	innerResponse := singleResponse{
 		CertID: certID{

--- a/ocsp/ocsp_test.go
+++ b/ocsp/ocsp_test.go
@@ -533,6 +533,49 @@ func createMultiResp() ([]byte, error) {
 		},
 	})
 }
+func selfSignedCA(t *testing.T, serial int64, cn string) (*x509.Certificate, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, key
+}
+
+func issuerHashesForTest(t *testing.T, issuer *x509.Certificate) ([]byte, []byte) {
+	t.Helper()
+	var publicKeyInfo struct {
+		Algorithm pkix.AlgorithmIdentifier
+		PublicKey asn1.BitString
+	}
+	if _, err := asn1.Unmarshal(issuer.RawSubjectPublicKeyInfo, &publicKeyInfo); err != nil {
+		t.Fatal(err)
+	}
+	h := sha1.New()
+	h.Write(publicKeyInfo.PublicKey.RightAlign())
+	keyHash := h.Sum(nil)
+	h.Reset()
+	h.Write(issuer.RawSubject)
+	nameHash := h.Sum(nil)
+	return nameHash, keyHash
+}
 
 func TestOCSPDecodeMultiResponse(t *testing.T) {
 	respBytes, err := createMultiResp()
@@ -559,6 +602,105 @@ func TestOCSPDecodeMultiResponseWithoutMatchingCert(t *testing.T) {
 	want := ParseError("no response matching the supplied certificate")
 	if err != want {
 		t.Errorf("err: got %q, want %q", err, want)
+	}
+}
+func TestParseResponseForCertMatchesFullCertIDWhenIssuerProvided(t *testing.T) {
+	issuerA, keyA := selfSignedCA(t, 1, "issuer-a")
+	issuerB, _ := selfSignedCA(t, 2, "issuer-b")
+	serial := big.NewInt(42)
+	nameHashA, keyHashA := issuerHashesForTest(t, issuerA)
+	nameHashB, keyHashB := issuerHashesForTest(t, issuerB)
+	sha1OID := getOIDFromHashAlgorithm(crypto.SHA1)
+
+	wrongFirst := singleResponse{
+		CertID: certID{
+			HashAlgorithm: pkix.AlgorithmIdentifier{
+				Algorithm:  sha1OID,
+				Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
+			},
+			NameHash:      nameHashB,
+			IssuerKeyHash: keyHashB,
+			SerialNumber:  serial,
+		},
+		ThisUpdate: time.Now().UTC(),
+		NextUpdate: time.Now().Add(time.Hour).UTC(),
+		Good:       true,
+	}
+	correctSecond := singleResponse{
+		CertID: certID{
+			HashAlgorithm: pkix.AlgorithmIdentifier{
+				Algorithm:  sha1OID,
+				Parameters: asn1.RawValue{Tag: 5 /* ASN.1 NULL */},
+			},
+			NameHash:      nameHashA,
+			IssuerKeyHash: keyHashA,
+			SerialNumber:  serial,
+		},
+		ThisUpdate: time.Now().UTC(),
+		NextUpdate: time.Now().Add(time.Hour).UTC(),
+		Revoked: revokedInfo{
+			RevocationTime: time.Now().UTC(),
+			Reason:         1,
+		},
+	}
+	rawResponderID := asn1.RawValue{
+		Class:      2, // context-specific
+		Tag:        1, // Name (explicit tag)
+		IsCompound: true,
+		Bytes:      issuerA.RawSubject,
+	}
+	tbsResponseData := responseData{
+		Version:        0,
+		RawResponderID: rawResponderID,
+		ProducedAt:     time.Now().Truncate(time.Minute).UTC(),
+		Responses:      []singleResponse{wrongFirst, correctSecond},
+	}
+	tbsResponseDataDER, err := asn1.Marshal(tbsResponseData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hashFunc, signatureAlgorithm, err := signingParamsForPublicKey(keyA.Public(), x509.SHA256WithRSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	responseHash := hashFunc.New()
+	responseHash.Write(tbsResponseDataDER)
+	signature, err := keyA.Sign(rand.Reader, responseHash.Sum(nil), hashFunc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response := basicResponse{
+		TBSResponseData:    tbsResponseData,
+		SignatureAlgorithm: signatureAlgorithm,
+		Signature: asn1.BitString{
+			Bytes:     signature,
+			BitLength: 8 * len(signature),
+		},
+	}
+	responseDER, err := asn1.Marshal(response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	respBytes, err := asn1.Marshal(responseASN1{
+		Status: asn1.Enumerated(Success),
+		Response: responseBytes{
+			ResponseType: idPKIXOCSPBasic,
+			Response:     responseDER,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := ParseResponseForCert(respBytes, &x509.Certificate{SerialNumber: serial}, issuerA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != Revoked {
+		t.Fatalf("resp.Status: got %v, want %v", resp.Status, Revoked)
+	}
+	if resp.RevocationReason != int(correctSecond.Revoked.Reason) {
+		t.Fatalf("resp.RevocationReason: got %v, want %v", resp.RevocationReason, correctSecond.Revoked.Reason)
 	}
 }
 


### PR DESCRIPTION
This changes `ParseResponseForCert` to require a full `CertID` match
when the caller supplies an issuer, rather than selecting a
`SingleResponse` by serial number alone.

When `issuer` is non-nil, the parser now compares:
- serial number
- issuer name hash
- issuer key hash

against the selected response entry.

It also factors issuer hash computation into a shared helper used by
`CreateRequest` and `CreateResponse`, and adds a regression test
covering duplicate serials across different issuers in a multi-response
OCSP payload.

No public `golang/go` issue is referenced here because this change comes
from a private security report.

Tested with:
- `go test ./ocsp`