### PR TITLE
ssh: reject source-address critical option on host certificates

### DIFF
--- a/ssh/certs.go
+++ b/ssh/certs.go
@@ -405,9 +405,14 @@ func (c *CertChecker) CheckCert(principal string, cert *Certificate) error {
 	}
 
 	for opt := range cert.CriticalOptions {
-		// sourceAddressCriticalOption will be enforced by
-		// serverAuthenticate
 		if opt == sourceAddressCriticalOption {
+			// source-address is only valid for user certificates.
+			// OpenSSH rejects host certificates containing this option.
+			if cert.CertType == HostCert {
+				return fmt.Errorf("ssh: unsupported critical option %q in host certificate", opt)
+			}
+			// For user certificates, source-address will be enforced by
+			// serverAuthenticate.
 			continue
 		}
 


### PR DESCRIPTION
Fixes golang/go#80872

## Problem

x/crypto/ssh clients will accept a host certificate containing a `source-address` critical option, which OpenSSH rejects. The `source-address` option should only apply to user certificates, not host certificates.

## Root cause

In `certs.go`, `CheckCert()` unconditionally skips the `source-address` critical option with the comment "sourceAddressCriticalOption will be enforced by serverAuthenticate", regardless of whether the certificate is a user or host certificate.

For user certificates this is correct — the server-side authentication dispatch loop enforces the source-address restriction. But for host certificates, `source-address` is an unsupported critical option that should be rejected.

## Fix

Check `cert.CertType` in the critical options loop: if `source-address` appears on a `HostCert`, return an error instead of skipping it. User certificates continue to skip it as before, preserving the existing server-side enforcement path.

## Changes

- `ssh/certs.go`: add `HostCert` type check for `source-address` critical option
