### PR TITLE
blake2b, blake2s: limit blocks processed at once in assembly

### DIFF
--- a/blake2b/blake2b.go
+++ b/blake2b/blake2b.go
@@ -35,6 +35,13 @@ const (
 	Size256 = 32
 )
 
+// The maximum number of bytes that can be passed to hashBlocks(). The limit
+// exists because implementations that rely on assembly routines are not
+// preemptible, so one call would otherwise hold every P in a stop-the-world
+// for as long as the input is.
+const maxAsmIters = 512
+const maxAsmSize = BlockSize * maxAsmIters // 64KiB
+
 var (
 	useAVX2 bool
 	useAVX  bool
@@ -123,6 +130,11 @@ func checkSum(sum *[Size]byte, hashSize int, data []byte) {
 		n := length &^ (BlockSize - 1)
 		if length == n {
 			n -= BlockSize
+		}
+		for n > maxAsmSize {
+			hashBlocks(&h, &c, 0, data[:maxAsmSize])
+			data = data[maxAsmSize:]
+			n -= maxAsmSize
 		}
 		hashBlocks(&h, &c, 0, data[:n])
 		data = data[n:]
@@ -231,6 +243,11 @@ func (d *digest) Write(p []byte) (n int, err error) {
 		nn := length &^ (BlockSize - 1)
 		if length == nn {
 			nn -= BlockSize
+		}
+		for nn > maxAsmSize {
+			hashBlocks(&d.h, &d.c, 0, p[:maxAsmSize])
+			p = p[maxAsmSize:]
+			nn -= maxAsmSize
 		}
 		hashBlocks(&d.h, &d.c, 0, p[:nn])
 		p = p[nn:]

--- a/blake2b/blake2b_test.go
+++ b/blake2b/blake2b_test.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"runtime"
 	"testing"
+	"time"
 )
 
 var _ hash.XOF = (*xof)(nil)
@@ -324,6 +326,7 @@ func benchmarkWrite(b *testing.B, size int) {
 }
 
 func BenchmarkWrite128(b *testing.B) { benchmarkWrite(b, 128) }
+func BenchmarkWrite1M(b *testing.B)  { benchmarkWrite(b, 1024*1024) }
 func BenchmarkWrite1K(b *testing.B)  { benchmarkWrite(b, 1024) }
 
 func BenchmarkSum128(b *testing.B) { benchmarkSum(b, 128) }
@@ -846,4 +849,50 @@ var hashes2X = []string{
 	"ff9c6125b2f60bfd6c2427b279df070e430075096647599bdc68c531152c58e13858b82385d78c856092d6c74106e87ccf51ac7e673936332d9b223444eaa0e762ee258d8a733d3a515ec68ed73285e5ca183ae3278b4820b0ab2797feb1e7d8cc864df585dfb5ebe02a993325a9ad5e2d7d49d3132cf66013898351d044e0fe908ccdfeeebf651983601e3673a1f92d36510c0cc19b2e75856db8e4a41f92a51efa66d6cc22e414944c2c34a5a89ccde0be76f51410824e330d8e7c613194338c93732e8aea651fca18bcf1ac1824340c5553aff1e58d4ab8d7c8842b4712021e517cd6c140f6743c69c7bee05b10a8f24050a8caa4f96d1664909c5a06",
 	"6e85c2f8e1fdc3aaeb969da1258cb504bbf0070cd03d23b3fb5ee08feea5ee2e0ee1c71a5d0f4f701b351f4e4b4d74cb1e2ae6184814f77b62d2f08134b7236ebf6b67d8a6c9f01b4248b30667c555f5d8646dbfe291151b23c9c9857e33a4d5c847be29a5ee7b402e03bac02d1a4319acc0dd8f25e9c7a266f5e5c896cc11b5b238df96a0963ae806cb277abc515c298a3e61a3036b177acf87a56ca4478c4c6d0d468913de602ec891318bbaf52c97a77c35c5b7d164816cf24e4c4b0b5f45853882f716d61eb947a45ce2efa78f1c70a918512af1ad536cbe6148083385b34e207f5f690d7a954021e4b5f4258a385fd8a87809a481f34202af4caccb82",
 	"1e9b2c454e9de3a2d723d850331037dbf54133dbe27488ff757dd255833a27d8eb8a128ad12d0978b6884e25737086a704fb289aaaccf930d5b582ab4df1f55f0c429b6875edec3fe45464fa74164be056a55e243c4222c586bec5b18f39036aa903d98180f24f83d09a454dfa1e03a60e6a3ba4613e99c35f874d790174ee48a557f4f021ade4d1b278d7997ef094569b37b3db0505951e9ee8400adaea275c6db51b325ee730c69df97745b556ae41cd98741e28aa3a49544541eeb3da1b1e8fa4e8e9100d66dd0c7f5e2c271b1ecc077de79c462b9fe4c273543ecd82a5bea63c5acc01eca5fb780c7d7c8c9fe208ae8bd50cad1769693d92c6c8649d20d8",
+}
+
+var sinkSTW []byte
+
+// BenchmarkSTW reports how long a garbage collection had to wait while a hash
+// ran alongside it, as gcwait-ns/op. Assembly is not preemptible, so a call
+// that covers the whole input blocks every goroutine in the process for as
+// long as it runs; bounding the call gives the collector a way in between
+// chunks. Both paths are covered: Write and the one-shot Sum512, which reaches
+// hashBlocks through checkSum rather than Write. Run with GOMAXPROCS>=2 so the
+// hash and the collection actually overlap.
+func BenchmarkSTW(b *testing.B) {
+	buf := make([]byte, 64<<20)
+	for _, tc := range []struct {
+		name string
+		hash func()
+	}{
+		{"Write", func() {
+			h, _ := New512(nil)
+			h.Write(buf)
+			sinkSTW = h.Sum(nil)
+		}},
+		{"Sum", func() {
+			sum := Sum512(buf)
+			sinkSTW = sum[:]
+		}},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			var total time.Duration
+			var iters int
+			b.SetBytes(int64(len(buf)))
+			for b.Loop() {
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					tc.hash()
+				}()
+				start := time.Now()
+				runtime.GC() // one per iteration, so the mean is well defined
+				total += time.Since(start)
+				iters++
+				<-done
+			}
+			b.ReportMetric(float64(total.Nanoseconds())/float64(iters), "gcwait-ns/op")
+		})
+	}
 }

--- a/blake2b/blake2b_test.go
+++ b/blake2b/blake2b_test.go
@@ -882,10 +882,15 @@ func BenchmarkSTW(b *testing.B) {
 			b.SetBytes(int64(len(buf)))
 			for b.Loop() {
 				done := make(chan struct{})
+				hashing := make(chan struct{})
 				go func() {
 					defer close(done)
+					close(hashing)
 					tc.hash()
 				}()
+				// Wait until the hash goroutine is running, so the collection
+				// below cannot finish before the hash has even started.
+				<-hashing
 				start := time.Now()
 				runtime.GC() // one per iteration, so the mean is well defined
 				total += time.Since(start)

--- a/blake2s/blake2s.go
+++ b/blake2s/blake2s.go
@@ -36,6 +36,13 @@ const (
 	Size128 = 16
 )
 
+// The maximum number of bytes that can be passed to hashBlocks(). The limit
+// exists because implementations that rely on assembly routines are not
+// preemptible, so one call would otherwise hold every P in a stop-the-world
+// for as long as the input is.
+const maxAsmIters = 1024
+const maxAsmSize = BlockSize * maxAsmIters // 64KiB
+
 var errKeySize = errors.New("blake2s: invalid key size")
 
 var iv = [8]uint32{
@@ -100,6 +107,11 @@ func checkSum(sum *[Size]byte, hashSize int, data []byte) {
 		n := length &^ (BlockSize - 1)
 		if length == n {
 			n -= BlockSize
+		}
+		for n > maxAsmSize {
+			hashBlocks(&h, &c, 0, data[:maxAsmSize])
+			data = data[maxAsmSize:]
+			n -= maxAsmSize
 		}
 		hashBlocks(&h, &c, 0, data[:n])
 		data = data[n:]
@@ -209,6 +221,11 @@ func (d *digest) Write(p []byte) (n int, err error) {
 		nn := length &^ (BlockSize - 1)
 		if length == nn {
 			nn -= BlockSize
+		}
+		for nn > maxAsmSize {
+			hashBlocks(&d.h, &d.c, 0, p[:maxAsmSize])
+			p = p[maxAsmSize:]
+			nn -= maxAsmSize
 		}
 		hashBlocks(&d.h, &d.c, 0, p[:nn])
 		p = p[nn:]

--- a/blake2s/blake2s_test.go
+++ b/blake2s/blake2s_test.go
@@ -9,7 +9,9 @@ import (
 	"encoding"
 	"encoding/hex"
 	"fmt"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func TestHashes(t *testing.T) {
@@ -264,6 +266,7 @@ func benchmarkWrite(b *testing.B, size int) {
 }
 
 func BenchmarkWrite64(b *testing.B) { benchmarkWrite(b, 64) }
+func BenchmarkWrite1M(b *testing.B) { benchmarkWrite(b, 1024*1024) }
 func BenchmarkWrite1K(b *testing.B) { benchmarkWrite(b, 1024) }
 
 func BenchmarkSum64(b *testing.B) { benchmarkSum(b, 64) }
@@ -1047,4 +1050,50 @@ var hashes2X = []string{
 	"50957c407519951bd32e45d21129d6b83436e520b0801ec8292d79a828106a41583a0d607f853dc4410e0a1427f7e873455a75df065cfc6eef970f7e49d123b346976460aadd91cf513c140c356442a84656904a8b1d708dc6089db371c36f4fe059c62302eaab3c06c0cb3b429961f899dcf99798464b8571a440cac7a52b495f32417af6bc8f58adc63647531f804b4e96273b29b42434c1236bde80ba3744fef7b1d11c2f9db332b35bc25123338ac9a0796aac213c9709b3c514ea7ecd80e22d3d8a74f28c8194418a6e1ff30714d0f5a61c068b73b2ba6cad14e05569b4a5a100da3f91429d6e3ffee10ceea057845ec6fc47a6c5125b22e598b2dc",
 	"f2273ec31e03cf42d9ca953f8b87e78c291cb538098e0f2436194b308ce30583f553fccb21ae6c2d58f3a5a2ca6037c1b8b7afb291009e4310a0c518e75314c5bb1e813bf521f56d0a4891d0772ad84f09a00634815029a3f9ad4e41eafb4a745e409ef3d4f0b1cf6232b70a5ce262b9432f096e834201a0992db5d09ffa5cbc5471460519a4bc7cdc33ae6dfe6ffc1e80ea5d29813136406499c3514186ced71854a340701519ef33b6c82ca67049ab58578ff49c4c4fbf7d97bfec2ecd8fbefec1b6d6467503fea9d26e134e8c35739a422647aaf4db29c9a32e3df36e5845791fdd75a70903e0ce808313a3327431b7772567f779bbaee2e134c109a387",
 	"5784e614d538f7f26c803191deb464a884817002988c36448dcbecfad1997fe51ab0b3853c51ed49ce9f4e477522fb3f32cc50515b753c18fb89a8d965afcf1ed5e099b22c4225732baeb986f5c5bc88e4582d27915e2a19126d3d4555fab4f6516a6a156dbfeed9e982fc589e33ce2b9e1ba2b416e11852ddeab93025974267ac82c84f071c3d07f215f47e3565fd1d962c76e0d635892ea71488273765887d31f250a26c4ddc377ed89b17326e259f6cc1de0e63158e83aebb7f5a7c08c63c767876c8203639958a407acca096d1f606c04b4f4b3fd771781a5901b1c3cee7c04c3b6870226eee309b74f51edbf70a3817cc8da87875301e04d0416a65dc5d",
+}
+
+var sinkSTW []byte
+
+// BenchmarkSTW reports how long a garbage collection had to wait while a hash
+// ran alongside it, as gcwait-ns/op. Assembly is not preemptible, so a call
+// that covers the whole input blocks every goroutine in the process for as
+// long as it runs; bounding the call gives the collector a way in between
+// chunks. Both paths are covered: Write and the one-shot Sum256, which reaches
+// hashBlocks through checkSum rather than Write. Run with GOMAXPROCS>=2 so the
+// hash and the collection actually overlap.
+func BenchmarkSTW(b *testing.B) {
+	buf := make([]byte, 64<<20)
+	for _, tc := range []struct {
+		name string
+		hash func()
+	}{
+		{"Write", func() {
+			h, _ := New256(nil)
+			h.Write(buf)
+			sinkSTW = h.Sum(nil)
+		}},
+		{"Sum", func() {
+			sum := Sum256(buf)
+			sinkSTW = sum[:]
+		}},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			var total time.Duration
+			var iters int
+			b.SetBytes(int64(len(buf)))
+			for b.Loop() {
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					tc.hash()
+				}()
+				start := time.Now()
+				runtime.GC() // one per iteration, so the mean is well defined
+				total += time.Since(start)
+				iters++
+				<-done
+			}
+			b.ReportMetric(float64(total.Nanoseconds())/float64(iters), "gcwait-ns/op")
+		})
+	}
 }

--- a/blake2s/blake2s_test.go
+++ b/blake2s/blake2s_test.go
@@ -1083,10 +1083,15 @@ func BenchmarkSTW(b *testing.B) {
 			b.SetBytes(int64(len(buf)))
 			for b.Loop() {
 				done := make(chan struct{})
+				hashing := make(chan struct{})
 				go func() {
 					defer close(done)
+					close(hashing)
 					tc.hash()
 				}()
+				// Wait until the hash goroutine is running, so the collection
+				// below cannot finish before the hash has even started.
+				<-hashing
 				start := time.Now()
 				runtime.GC() // one per iteration, so the mean is well defined
 				total += time.Since(start)


### PR DESCRIPTION
**Problem:** GC stop-the-world is slow if a large input is passed to Write or Sum512.

**Root cause:** hashBlocks() is handed unbounded input, and assembly is not
preemptible, so one call keeps every P in stop-the-world for as long as it
runs. CL 671098 bounded crypto/md5 and crypto/sha256 the same way.

Stop-the-world (improved)

Worst stop-the-world stopping pause, /sched/pauses/stopping/gc:seconds, which
is the time the runtime spends waiting for every P to halt, while hashing a
64 MiB buffer. linux/amd64, EPYC 4344P, GOMAXPROCS=2. Values are histogram
bucket upper bounds, so read them as "at most":

                 before        after      pauses over 1ms
    blake2b      58.72ms       66us          3 -> 0
    blake2s      83.886ms      164us         3 -> 0

BenchmarkSTW, added here, reports the same effect as the wall time of one
runtime.GC() that overlaps the hash, for both paths:

    GOMAXPROCS=2 go test -run='^$' -bench=BenchmarkSTW -count=6 -benchtime=2s ./blake2b/ ./blake2s/
    benchstat before.txt after.txt

    blake2b           gcwait-sec/op   gcwait-sec/op  vs base
    STW/Write-2        50765.1µ ± 0%    444.2µ ±  5%  -99.13% (p=0.002 n=6)
    STW/Sum-2          50759.7µ ± 0%    434.3µ ± 28%  -99.14% (p=0.002 n=6)

    blake2s           gcwait-sec/op   gcwait-sec/op  vs base
    STW/Write-2        74686.5µ ± 0%    504.5µ ± 33%  -99.32% (p=0.002 n=6)
    STW/Sum-2          74578.3µ ± 0%    480.7µ ± 15%  -99.36% (p=0.002 n=6)

The before column is flat at 0% because it is not measuring the collector at
all, it is measuring the hash. The variance that appears afterwards is the
collector's own work.

Throughput (no degradations)

    for i in $(seq 8); do
      GOMAXPROCS=2 go test -run='^$' -bench='BenchmarkWrite|BenchmarkSum' -count=3 -benchtime=200ms ./blake2b/ ./blake2s/
    done
    benchstat before.txt after.txt

    blake2b            sec/op        sec/op     vs base
    Write128-2     101.2n ± 0%   101.1n ± 0%  -0.15% (p=0.017 n=24)
    Write1M-2      784.7µ ± 0%   785.0µ ± 0%  +0.04% (p=0.032 n=24)
    Write1K-2      774.5n ± 0%   774.0n ± 0%       ~ (p=0.370 n=24)
    Sum128-2       106.8n ± 0%   106.7n ± 0%       ~ (p=0.093 n=24)
    Sum1K-2        779.7n ± 0%   781.8n ± 0%  +0.27% (p=0.017 n=24)
    geomean        1.387µ        1.387µ       +0.00%

    blake2s            sec/op        sec/op     vs base
    Write64-2      76.65n ± 0%   76.55n ± 0%       ~ (p=0.415 n=24)
    Write1M-2      1.154m ± 0%   1.154m ± 0%       ~ (p=0.178 n=24)
    Write1K-2      1.141µ ± 0%   1.142µ ± 0%       ~ (p=0.527 n=24)
    Sum64-2        84.86n ± 0%   83.61n ± 0%  -1.47% (p=0.000 n=24)
    Sum1K-2        1.150µ ± 0%   1.149µ ± 0%  -0.09% (p=0.001 n=24)
    geomean        1.580µ        1.575µ       -0.32%


Updates golang/go#64417
